### PR TITLE
c12writer writes special banks.

### DIFF
--- a/Clas12Banks/clas12reader.cpp
+++ b/Clas12Banks/clas12reader.cpp
@@ -332,10 +332,9 @@ namespace clas12 {
     if(_btraj.get())_allBanks.push_back(_btraj.get());
     if(_bcher.get())_allBanks.push_back(_bcher.get());
     if(_bft.get())_allBanks.push_back(_bft.get());
+    if(_bvtp.get())_allBanks.push_back(_bvtp.get());
+    
 
-    //Comment in next 2 lines for helicity analysis
-    //if(_bhelonline.get())_allBanks.push_back(*_bhelonline.get());
-    //if(_bhelflip.get())_allBanks.push_back(*_bhelflip.get());
   }
 
 }

--- a/Clas12Banks/clas12reader.h
+++ b/Clas12Banks/clas12reader.h
@@ -73,6 +73,7 @@ namespace clas12 {
     
     std::vector<hipo::bank* > getAllBanksPtrs(){return _allBanks;}
     hipo::dictionary& getDictionary(){return _factory;}
+    std::string getFilename(){return _filename;}
     
     void addARegionFDet(){
       //Forward detector needs particles, calorimeter, scintillator,

--- a/Clas12Banks/clas12writer.h
+++ b/Clas12Banks/clas12writer.h
@@ -39,8 +39,7 @@ namespace clas12 {
     clas12writer(std::string filename);
     virtual ~clas12writer()=default;
 
-    hipo::writer& getWriter(){return _writer;}
-    
+    hipo::writer& getWriter(){return _writer;}   
    
     void writeEvent();
     void clearEvent();
@@ -49,6 +48,11 @@ namespace clas12 {
     void openFile();
     bool savedBankName(std::string name);
     void assignReader(clas12reader& c12reader);
+    void writeSpecialBanks(bool specialBanksBool){_specialBanksBool=specialBanksBool;};
+    void processSpecialBanks(std::string inputFilename);
+    void addSchema(std::string schemaName, hipo::dictionary& factory);
+    bool hasSchema(std::string schemaName);
+    void setTag(long tag);
 
     //////////////////////////////////////////////////////////////////////////////////////////
     ///adds a bank name to the list of banks to skip
@@ -59,13 +63,16 @@ namespace clas12 {
     } 
     
   private:
-
+    
     //reader
     hipo::writer     _writer;
     hipo::event      _outEvent;
     std::vector<std::string> _bankNamesToSkip;
     std::string _filename;
     std::vector<hipo::bank* > _banks;
+    bool _specialBanksBool = true;
+    long _nEvents = 0;
+    long _nSpecialEvents = 0;
   }; 
 
 }

--- a/hipo4/recordbuilder.cpp
+++ b/hipo4/recordbuilder.cpp
@@ -13,9 +13,9 @@
 
 namespace hipo {
   /**
-  * Default constructor sets number of max events to 100000
-  * and the buffer size to 8MB.
-  */
+   * Default constructor sets number of max events to 100000
+   * and the buffer size to 8MB.
+   */
   recordbuilder::recordbuilder(){
     bufferIndex.resize(4*defaultNumberOfEvents);
     bufferEvents.resize(defaultRecordSize);
@@ -39,9 +39,9 @@ namespace hipo {
 
   /**
    * add event object to the record builder buffer.
-  */
+   */
   bool recordbuilder::addEvent(hipo::event &evnt){
-      return addEvent(evnt.getEventBuffer(),0,evnt.getSize());
+    return addEvent(evnt.getEventBuffer(),0,evnt.getSize());
   }
   /**
    * add a content of a vector to the record builder buffer.
@@ -49,13 +49,13 @@ namespace hipo {
    * by user.
    */
   bool recordbuilder::addEvent(std::vector<char> &vec, int start, int length){
-      if((bufferEventsPosition+length)>=bufferEvents.size()) return false;
-      if((bufferIndexEntries+1)*4>=bufferIndex.size()) return false;
-      *reinterpret_cast<int*>(&bufferIndex[bufferIndexEntries*4]) = length;
-      bufferIndexEntries++;
-      memcpy(&bufferEvents[bufferEventsPosition],&vec[start],length);
-      bufferEventsPosition += length;
-      return true;
+    if((bufferEventsPosition+length)>=bufferEvents.size()) return false;
+    if((bufferIndexEntries+1)*4>=bufferIndex.size()) return false;
+    *reinterpret_cast<int*>(&bufferIndex[bufferIndexEntries*4]) = length;
+    bufferIndexEntries++;
+    memcpy(&bufferEvents[bufferEventsPosition],&vec[start],length);
+    bufferEventsPosition += length;
+    return true;
   }
   /**
    * Resets the counters for number of events and sets the
@@ -87,8 +87,8 @@ namespace hipo {
    * returns the size of the record.
    */
   int  recordbuilder::getRecordSize(){
-      int size = *reinterpret_cast<int*>(&bufferRecord[0]);
-      return size*4;
+    int size = *reinterpret_cast<int*>(&bufferRecord[0]);
+    return size*4;
   }
 
   long recordbuilder::getUserWordOne(){
@@ -101,34 +101,44 @@ namespace hipo {
     return wTwo;
   }
 
-  void recordbuilder::build(){
-      int  indexSize = bufferIndexEntries*4;
-      int eventsSize = bufferEventsPosition;
-      memcpy(&bufferData[0],&bufferIndex[0],indexSize);
-      memcpy(&bufferData[indexSize],&bufferEvents[0],eventsSize);
-      int uncompressedSize = indexSize+eventsSize;
-      int   compressedSize = compressRecord(uncompressedSize);
-      int         rounding = getRecordLengthRounding(compressedSize);
-      int   compressedSizeToWrite = compressedSize + rounding;
-      int   compressedSizeToWriteWords =  compressedSizeToWrite/4;
-      int            recordLength = compressedSizeToWrite/4+14;
+  void recordbuilder::setUserWordOne(long userWordOne){
+    bufferUserWordOne = userWordOne;
+  }
 
-      hipo::utils::writeInt(&bufferRecord[0],  0, recordLength); // (1) - record length in words (includes header)
-      hipo::utils::writeInt(&bufferRecord[0],  4, 0); // (2) - record #
-      hipo::utils::writeInt(&bufferRecord[0],  8, 14); // (3) - record header lenght (in words)
-      hipo::utils::writeInt(&bufferRecord[0], 12, bufferIndexEntries); // (4) event count in the record
-      hipo::utils::writeInt(&bufferRecord[0], 16, bufferIndexEntries*4); // (5) length of index array in bytes
-      int versionWord = (rounding<<24)|(6);
-      hipo::utils::writeInt(&bufferRecord[0], 20, versionWord); // (6) record version number
-      hipo::utils::writeInt(&bufferRecord[0], 24, 0); // (7) user header length bytes
-      hipo::utils::writeInt(&bufferRecord[0], 28, 0xc0da0100); // (8) magic word
-      hipo::utils::writeInt(&bufferRecord[0], 32, eventsSize); // (9) magic word
-      int compressionWord = (1<<28)|(0x0FFFFFFF&compressedSizeToWriteWords);
-      hipo::utils::writeInt(&bufferRecord[0], 36, compressionWord);
-      hipo::utils::writeLong(&bufferRecord[0], 40, 0);
-      hipo::utils::writeLong(&bufferRecord[0], 48, 0);
-      //printf("record::build uncompressed size = %8d, compressed size = %8d, rounding = %4d , compressed FULL = %6d, record size = %6d, version = %X, size = %5X\n",
-      //      uncompressedSize,compressedSize, rounding,compressedSizeToWrite, recordLength*4,versionWord,compressionWord);
+  void recordbuilder::setUserWordTwo(long userWordTwo){
+    bufferUserWordTwo = userWordTwo;
+  } 
+    
+
+  void recordbuilder::build(){
+
+    int  indexSize = bufferIndexEntries*4;
+    int eventsSize = bufferEventsPosition;
+    memcpy(&bufferData[0],&bufferIndex[0],indexSize);
+    memcpy(&bufferData[indexSize],&bufferEvents[0],eventsSize);
+    int uncompressedSize = indexSize+eventsSize;
+    int   compressedSize = compressRecord(uncompressedSize);
+    int         rounding = getRecordLengthRounding(compressedSize);
+    int   compressedSizeToWrite = compressedSize + rounding;
+    int   compressedSizeToWriteWords =  compressedSizeToWrite/4;
+    int            recordLength = compressedSizeToWrite/4+14;
+
+    hipo::utils::writeInt(&bufferRecord[0],  0, recordLength); // (1) - record length in words (includes header)
+    hipo::utils::writeInt(&bufferRecord[0],  4, 0); // (2) - record #
+    hipo::utils::writeInt(&bufferRecord[0],  8, 14); // (3) - record header lenght (in words)
+    hipo::utils::writeInt(&bufferRecord[0], 12, bufferIndexEntries); // (4) event count in the record
+    hipo::utils::writeInt(&bufferRecord[0], 16, bufferIndexEntries*4); // (5) length of index array in bytes
+    int versionWord = (rounding<<24)|(6);
+    hipo::utils::writeInt(&bufferRecord[0], 20, versionWord); // (6) record version number
+    hipo::utils::writeInt(&bufferRecord[0], 24, 0); // (7) user header length bytes
+    hipo::utils::writeInt(&bufferRecord[0], 28, 0xc0da0100); // (8) magic word
+    hipo::utils::writeInt(&bufferRecord[0], 32, eventsSize); // (9) magic word
+    int compressionWord = (1<<28)|(0x0FFFFFFF&compressedSizeToWriteWords);
+    hipo::utils::writeInt(&bufferRecord[0], 36, compressionWord);
+    hipo::utils::writeLong(&bufferRecord[0], 40, bufferUserWordOne);
+    hipo::utils::writeLong(&bufferRecord[0], 48, bufferUserWordTwo);
+    //printf("record::build uncompressed size = %8d, compressed size = %8d, rounding = %4d , compressed FULL = %6d, record size = %6d, version = %X, size = %5X\n",
+    //      uncompressedSize,compressedSize, rounding,compressedSizeToWrite, recordLength*4,versionWord,compressionWord);
   }
   /**
    * Compresses the constructed buffer with LZ4 into internal buffer that
@@ -136,24 +146,24 @@ namespace hipo {
    */
   int  recordbuilder::compressRecord(int src_size){
 
-    #ifdef __LZ4__
+#ifdef __LZ4__
     //(const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
-      int result = LZ4_compress_fast(&bufferData[0],&bufferRecord[56],src_size,bufferRecord.size(),1);
+    int result = LZ4_compress_fast(&bufferData[0],&bufferRecord[56],src_size,bufferRecord.size(),1);
 
-      //int   result = LZ4_decompress_safe(data,output,dataLength,dataLengthUncompressed);
-      //int   result = LZ4_decompress_fast(data,output,dataLengthUncompressed);
-      return result;
-      //printf(" FIRST (%d) = %x %x %x %x\n",result);//,destUnCompressed[0],destUnCompressed[1],
-      //destUnCompressed[2],destUnCompressed[3]);
-      //LZ4_decompress_fast(buffer,destUnCompressed,decompressedLength);
-      //LZ4_uncompress(buffer,destUnCompressed,decompressedLength);
-      #endif
+    //int   result = LZ4_decompress_safe(data,output,dataLength,dataLengthUncompressed);
+    //int   result = LZ4_decompress_fast(data,output,dataLengthUncompressed);
+    return result;
+    //printf(" FIRST (%d) = %x %x %x %x\n",result);//,destUnCompressed[0],destUnCompressed[1],
+    //destUnCompressed[2],destUnCompressed[3]);
+    //LZ4_decompress_fast(buffer,destUnCompressed,decompressedLength);
+    //LZ4_uncompress(buffer,destUnCompressed,decompressedLength);
+#endif
 
-      #ifndef __LZ4__
-        printf("\n   >>>>> LZ4 compression is not supported.");
-        printf("\n   >>>>> check if libz4 is installed on your system.");
-        printf("\n   >>>>> recompile the library with liblz4 installed.\n");
-        return 0;
-      #endif
+#ifndef __LZ4__
+    printf("\n   >>>>> LZ4 compression is not supported.");
+    printf("\n   >>>>> check if libz4 is installed on your system.");
+    printf("\n   >>>>> recompile the library with liblz4 installed.\n");
+    return 0;
+#endif
   }
 }

--- a/hipo4/recordbuilder.cpp
+++ b/hipo4/recordbuilder.cpp
@@ -13,9 +13,9 @@
 
 namespace hipo {
   /**
-   * Default constructor sets number of max events to 100000
-   * and the buffer size to 8MB.
-   */
+  * Default constructor sets number of max events to 100000
+  * and the buffer size to 8MB.
+  */
   recordbuilder::recordbuilder(){
     bufferIndex.resize(4*defaultNumberOfEvents);
     bufferEvents.resize(defaultRecordSize);
@@ -39,9 +39,9 @@ namespace hipo {
 
   /**
    * add event object to the record builder buffer.
-   */
+  */
   bool recordbuilder::addEvent(hipo::event &evnt){
-    return addEvent(evnt.getEventBuffer(),0,evnt.getSize());
+      return addEvent(evnt.getEventBuffer(),0,evnt.getSize());
   }
   /**
    * add a content of a vector to the record builder buffer.
@@ -49,13 +49,13 @@ namespace hipo {
    * by user.
    */
   bool recordbuilder::addEvent(std::vector<char> &vec, int start, int length){
-    if((bufferEventsPosition+length)>=bufferEvents.size()) return false;
-    if((bufferIndexEntries+1)*4>=bufferIndex.size()) return false;
-    *reinterpret_cast<int*>(&bufferIndex[bufferIndexEntries*4]) = length;
-    bufferIndexEntries++;
-    memcpy(&bufferEvents[bufferEventsPosition],&vec[start],length);
-    bufferEventsPosition += length;
-    return true;
+      if((bufferEventsPosition+length)>=bufferEvents.size()) return false;
+      if((bufferIndexEntries+1)*4>=bufferIndex.size()) return false;
+      *reinterpret_cast<int*>(&bufferIndex[bufferIndexEntries*4]) = length;
+      bufferIndexEntries++;
+      memcpy(&bufferEvents[bufferEventsPosition],&vec[start],length);
+      bufferEventsPosition += length;
+      return true;
   }
   /**
    * Resets the counters for number of events and sets the
@@ -87,8 +87,8 @@ namespace hipo {
    * returns the size of the record.
    */
   int  recordbuilder::getRecordSize(){
-    int size = *reinterpret_cast<int*>(&bufferRecord[0]);
-    return size*4;
+      int size = *reinterpret_cast<int*>(&bufferRecord[0]);
+      return size*4;
   }
 
   long recordbuilder::getUserWordOne(){
@@ -108,37 +108,35 @@ namespace hipo {
   void recordbuilder::setUserWordTwo(long userWordTwo){
     bufferUserWordTwo = userWordTwo;
   } 
-    
 
   void recordbuilder::build(){
+      int  indexSize = bufferIndexEntries*4;
+      int eventsSize = bufferEventsPosition;
+      memcpy(&bufferData[0],&bufferIndex[0],indexSize);
+      memcpy(&bufferData[indexSize],&bufferEvents[0],eventsSize);
+      int uncompressedSize = indexSize+eventsSize;
+      int   compressedSize = compressRecord(uncompressedSize);
+      int         rounding = getRecordLengthRounding(compressedSize);
+      int   compressedSizeToWrite = compressedSize + rounding;
+      int   compressedSizeToWriteWords =  compressedSizeToWrite/4;
+      int            recordLength = compressedSizeToWrite/4+14;
 
-    int  indexSize = bufferIndexEntries*4;
-    int eventsSize = bufferEventsPosition;
-    memcpy(&bufferData[0],&bufferIndex[0],indexSize);
-    memcpy(&bufferData[indexSize],&bufferEvents[0],eventsSize);
-    int uncompressedSize = indexSize+eventsSize;
-    int   compressedSize = compressRecord(uncompressedSize);
-    int         rounding = getRecordLengthRounding(compressedSize);
-    int   compressedSizeToWrite = compressedSize + rounding;
-    int   compressedSizeToWriteWords =  compressedSizeToWrite/4;
-    int            recordLength = compressedSizeToWrite/4+14;
-
-    hipo::utils::writeInt(&bufferRecord[0],  0, recordLength); // (1) - record length in words (includes header)
-    hipo::utils::writeInt(&bufferRecord[0],  4, 0); // (2) - record #
-    hipo::utils::writeInt(&bufferRecord[0],  8, 14); // (3) - record header lenght (in words)
-    hipo::utils::writeInt(&bufferRecord[0], 12, bufferIndexEntries); // (4) event count in the record
-    hipo::utils::writeInt(&bufferRecord[0], 16, bufferIndexEntries*4); // (5) length of index array in bytes
-    int versionWord = (rounding<<24)|(6);
-    hipo::utils::writeInt(&bufferRecord[0], 20, versionWord); // (6) record version number
-    hipo::utils::writeInt(&bufferRecord[0], 24, 0); // (7) user header length bytes
-    hipo::utils::writeInt(&bufferRecord[0], 28, 0xc0da0100); // (8) magic word
-    hipo::utils::writeInt(&bufferRecord[0], 32, eventsSize); // (9) magic word
-    int compressionWord = (1<<28)|(0x0FFFFFFF&compressedSizeToWriteWords);
-    hipo::utils::writeInt(&bufferRecord[0], 36, compressionWord);
-    hipo::utils::writeLong(&bufferRecord[0], 40, bufferUserWordOne);
-    hipo::utils::writeLong(&bufferRecord[0], 48, bufferUserWordTwo);
-    //printf("record::build uncompressed size = %8d, compressed size = %8d, rounding = %4d , compressed FULL = %6d, record size = %6d, version = %X, size = %5X\n",
-    //      uncompressedSize,compressedSize, rounding,compressedSizeToWrite, recordLength*4,versionWord,compressionWord);
+      hipo::utils::writeInt(&bufferRecord[0],  0, recordLength); // (1) - record length in words (includes header)
+      hipo::utils::writeInt(&bufferRecord[0],  4, 0); // (2) - record #
+      hipo::utils::writeInt(&bufferRecord[0],  8, 14); // (3) - record header lenght (in words)
+      hipo::utils::writeInt(&bufferRecord[0], 12, bufferIndexEntries); // (4) event count in the record
+      hipo::utils::writeInt(&bufferRecord[0], 16, bufferIndexEntries*4); // (5) length of index array in bytes
+      int versionWord = (rounding<<24)|(6);
+      hipo::utils::writeInt(&bufferRecord[0], 20, versionWord); // (6) record version number
+      hipo::utils::writeInt(&bufferRecord[0], 24, 0); // (7) user header length bytes
+      hipo::utils::writeInt(&bufferRecord[0], 28, 0xc0da0100); // (8) magic word
+      hipo::utils::writeInt(&bufferRecord[0], 32, eventsSize); // (9) magic word
+      int compressionWord = (1<<28)|(0x0FFFFFFF&compressedSizeToWriteWords);
+      hipo::utils::writeInt(&bufferRecord[0], 36, compressionWord);
+      hipo::utils::writeLong(&bufferRecord[0], 40, bufferUserWordOne);
+      hipo::utils::writeLong(&bufferRecord[0], 48, bufferUserWordTwo);
+      //printf("record::build uncompressed size = %8d, compressed size = %8d, rounding = %4d , compressed FULL = %6d, record size = %6d, version = %X, size = %5X\n",
+      //      uncompressedSize,compressedSize, rounding,compressedSizeToWrite, recordLength*4,versionWord,compressionWord);
   }
   /**
    * Compresses the constructed buffer with LZ4 into internal buffer that
@@ -146,24 +144,24 @@ namespace hipo {
    */
   int  recordbuilder::compressRecord(int src_size){
 
-#ifdef __LZ4__
+    #ifdef __LZ4__
     //(const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
-    int result = LZ4_compress_fast(&bufferData[0],&bufferRecord[56],src_size,bufferRecord.size(),1);
+      int result = LZ4_compress_fast(&bufferData[0],&bufferRecord[56],src_size,bufferRecord.size(),1);
 
-    //int   result = LZ4_decompress_safe(data,output,dataLength,dataLengthUncompressed);
-    //int   result = LZ4_decompress_fast(data,output,dataLengthUncompressed);
-    return result;
-    //printf(" FIRST (%d) = %x %x %x %x\n",result);//,destUnCompressed[0],destUnCompressed[1],
-    //destUnCompressed[2],destUnCompressed[3]);
-    //LZ4_decompress_fast(buffer,destUnCompressed,decompressedLength);
-    //LZ4_uncompress(buffer,destUnCompressed,decompressedLength);
-#endif
+      //int   result = LZ4_decompress_safe(data,output,dataLength,dataLengthUncompressed);
+      //int   result = LZ4_decompress_fast(data,output,dataLengthUncompressed);
+      return result;
+      //printf(" FIRST (%d) = %x %x %x %x\n",result);//,destUnCompressed[0],destUnCompressed[1],
+      //destUnCompressed[2],destUnCompressed[3]);
+      //LZ4_decompress_fast(buffer,destUnCompressed,decompressedLength);
+      //LZ4_uncompress(buffer,destUnCompressed,decompressedLength);
+      #endif
 
-#ifndef __LZ4__
-    printf("\n   >>>>> LZ4 compression is not supported.");
-    printf("\n   >>>>> check if libz4 is installed on your system.");
-    printf("\n   >>>>> recompile the library with liblz4 installed.\n");
-    return 0;
-#endif
+      #ifndef __LZ4__
+        printf("\n   >>>>> LZ4 compression is not supported.");
+        printf("\n   >>>>> check if libz4 is installed on your system.");
+        printf("\n   >>>>> recompile the library with liblz4 installed.\n");
+        return 0;
+      #endif
   }
 }

--- a/hipo4/recordbuilder.h
+++ b/hipo4/recordbuilder.h
@@ -40,6 +40,8 @@ namespace hipo {
 
         int                bufferIndexEntries;
         int                bufferEventsPosition;
+	long                bufferUserWordOne = 0;
+	long                bufferUserWordTwo = 0;
 
         int                compressRecord(int src_size);
         int                getRecordLengthRounding(int bufferSize);
@@ -55,6 +57,8 @@ namespace hipo {
 
         long getUserWordOne();
         long getUserWordTwo();
+	void setUserWordOne(long userWordOne);
+	void setUserWordTwo(long userWordTwo);
 
         int  getRecordSize();
         int  getEntries();

--- a/hipo4/recordbuilder.h
+++ b/hipo4/recordbuilder.h
@@ -40,8 +40,8 @@ namespace hipo {
 
         int                bufferIndexEntries;
         int                bufferEventsPosition;
-	long                bufferUserWordOne = 0;
-	long                bufferUserWordTwo = 0;
+	long               bufferUserWordOne = 0;
+	long               bufferUserWordTwo = 0;
 
         int                compressRecord(int src_size);
         int                getRecordLengthRounding(int bufferSize);

--- a/hipo4/writer.cpp
+++ b/hipo4/writer.cpp
@@ -1,6 +1,31 @@
+//******************************************************************************
+//*       ██╗  ██╗██╗██████╗  ██████╗     ██╗  ██╗    ██████╗                  *
+//*       ██║  ██║██║██╔══██╗██╔═══██╗    ██║  ██║   ██╔═████╗                 *
+//*       ███████║██║██████╔╝██║   ██║    ███████║   ██║██╔██║                 *
+//*       ██╔══██║██║██╔═══╝ ██║   ██║    ╚════██║   ████╔╝██║                 *
+//*       ██║  ██║██║██║     ╚██████╔╝         ██║██╗╚██████╔╝                 *
+//*       ╚═╝  ╚═╝╚═╝╚═╝      ╚═════╝          ╚═╝╚═╝ ╚═════╝                  *
+//************************ Jefferson National Lab (2017) ***********************
 /*
- * This sowftware was developed at Jefferson National Laboratory.
- * (c) 2017.
+ *   Copyright (c) 2017.  Jefferson Lab (JLab). All rights reserved. Permission
+ *   to use, copy, modify, and distribute  this software and its documentation
+ *   for educational, research, and not-for-profit purposes, without fee and
+ *   without a signed licensing agreement.
+ *
+ *   IN NO EVENT SHALL JLAB BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL
+ *   INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING
+ *   OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF JLAB HAS
+ *   BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *   JLAB SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *   PURPOSE. THE HIPO DATA FORMAT SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ *   ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". JLAB HAS NO OBLIGATION TO
+ *   PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *   This software was developed under the United States Government license.
+ *   For more information contact author at gavalian@jlab.org
+ *   Department of Experimental Nuclear Physics, Jefferson Lab.
  */
 
 #include "writer.h"
@@ -82,6 +107,16 @@ void writer::addDictionary(hipo::dictionary &dict){
    }
  }
 
+void writer::addEvent(std::vector<char> &vec, int size ){
+  int transferSize = size;
+  if(size<0){ transferSize = vec.size(); }
+  bool status = recordBuilder.addEvent(vec,0,transferSize);
+  if(status==false){
+    writeRecord(recordBuilder);
+    recordBuilder.addEvent(vec,0,transferSize);
+  }
+}
+
  void writer::writeRecord(recordbuilder &builder){
    builder.build();
    recordInfo_t  recordInfo;
@@ -146,25 +181,25 @@ void writer::close(){
   outputStream.close();
 }
 
-  /***
-   * Function to change the record builder user word one
-   */
-  void writer::setUserIntegerOne(long userIntOne){
-    recordBuilder.setUserWordOne(userIntOne);
-  }
+/***
+* Function to change the record builder user word one
+*/
+void writer::setUserIntegerOne(long userIntOne){
+  recordBuilder.setUserWordOne(userIntOne);
+}
 
-  /***
-   *Function to change the record builder user word two
-   */
-  void writer::setUserIntegerTwo(long userIntTwo){
-    recordBuilder.setUserWordTwo(userIntTwo);
-  }
+/***
+*Function to change the record builder user word two
+*/
+void writer::setUserIntegerTwo(long userIntTwo){
+  recordBuilder.setUserWordTwo(userIntTwo);
+}
 
-  /***
-   *Function to write buffer.
-   */
-  void writer::flush(){
-    writeRecord(recordBuilder);
-  }
+/***
+*Function to write buffer.
+*/
+void writer::flush(){
+  writeRecord(recordBuilder);
+}
 
 }

--- a/hipo4/writer.cpp
+++ b/hipo4/writer.cpp
@@ -1,31 +1,6 @@
-//******************************************************************************
-//*       ██╗  ██╗██╗██████╗  ██████╗     ██╗  ██╗    ██████╗                  *
-//*       ██║  ██║██║██╔══██╗██╔═══██╗    ██║  ██║   ██╔═████╗                 *
-//*       ███████║██║██████╔╝██║   ██║    ███████║   ██║██╔██║                 *
-//*       ██╔══██║██║██╔═══╝ ██║   ██║    ╚════██║   ████╔╝██║                 *
-//*       ██║  ██║██║██║     ╚██████╔╝         ██║██╗╚██████╔╝                 *
-//*       ╚═╝  ╚═╝╚═╝╚═╝      ╚═════╝          ╚═╝╚═╝ ╚═════╝                  *
-//************************ Jefferson National Lab (2017) ***********************
 /*
- *   Copyright (c) 2017.  Jefferson Lab (JLab). All rights reserved. Permission
- *   to use, copy, modify, and distribute  this software and its documentation
- *   for educational, research, and not-for-profit purposes, without fee and
- *   without a signed licensing agreement.
- *
- *   IN NO EVENT SHALL JLAB BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL
- *   INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING
- *   OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF JLAB HAS
- *   BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *   JLAB SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- *   PURPOSE. THE HIPO DATA FORMAT SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
- *   ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". JLAB HAS NO OBLIGATION TO
- *   PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
- *
- *   This software was developed under the United States Government license.
- *   For more information contact author at gavalian@jlab.org
- *   Department of Experimental Nuclear Physics, Jefferson Lab.
+ * This sowftware was developed at Jefferson National Laboratory.
+ * (c) 2017.
  */
 
 #include "writer.h"
@@ -107,16 +82,6 @@ void writer::addDictionary(hipo::dictionary &dict){
    }
  }
 
-void writer::addEvent(std::vector<char> &vec, int size ){
-  int transferSize = size;
-  if(size<0){ transferSize = vec.size(); }
-  bool status = recordBuilder.addEvent(vec,0,transferSize);
-  if(status==false){
-    writeRecord(recordBuilder);
-    recordBuilder.addEvent(vec,0,transferSize);
-  }
-}
-
  void writer::writeRecord(recordbuilder &builder){
    builder.build();
    recordInfo_t  recordInfo;
@@ -180,5 +145,26 @@ void writer::close(){
   writeIndexTable();
   outputStream.close();
 }
+
+  /***
+   * Function to change the record builder user word one
+   */
+  void writer::setUserIntegerOne(long userIntOne){
+    recordBuilder.setUserWordOne(userIntOne);
+  }
+
+  /***
+   *Function to change the record builder user word two
+   */
+  void writer::setUserIntegerTwo(long userIntTwo){
+    recordBuilder.setUserWordTwo(userIntTwo);
+  }
+
+  /***
+   *Function to write buffer.
+   */
+  void writer::flush(){
+    writeRecord(recordBuilder);
+  }
 
 }

--- a/hipo4/writer.h
+++ b/hipo4/writer.h
@@ -1,3 +1,32 @@
+//******************************************************************************
+//*       ██╗  ██╗██╗██████╗  ██████╗     ██╗  ██╗    ██████╗                  *
+//*       ██║  ██║██║██╔══██╗██╔═══██╗    ██║  ██║   ██╔═████╗                 *
+//*       ███████║██║██████╔╝██║   ██║    ███████║   ██║██╔██║                 *
+//*       ██╔══██║██║██╔═══╝ ██║   ██║    ╚════██║   ████╔╝██║                 *
+//*       ██║  ██║██║██║     ╚██████╔╝         ██║██╗╚██████╔╝                 *
+//*       ╚═╝  ╚═╝╚═╝╚═╝      ╚═════╝          ╚═╝╚═╝ ╚═════╝                  *
+//************************ Jefferson National Lab (2017) ***********************
+/*
+ *   Copyright (c) 2017.  Jefferson Lab (JLab). All rights reserved. Permission
+ *   to use, copy, modify, and distribute  this software and its documentation
+ *   for educational, research, and not-for-profit purposes, without fee and
+ *   without a signed licensing agreement.
+ *
+ *   IN NO EVENT SHALL JLAB BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL
+ *   INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING
+ *   OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF JLAB HAS
+ *   BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *   JLAB SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *   PURPOSE. THE HIPO DATA FORMAT SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ *   ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". JLAB HAS NO OBLIGATION TO
+ *   PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *   This software was developed under the United States Government license.
+ *   For more information contact author at gavalian@jlab.org
+ *   Department of Experimental Nuclear Physics, Jefferson Lab.
+ */
 /*
  *This sowftware was developed at Jefferson National Laboratory.
  */
@@ -59,7 +88,7 @@
   * @since 6.0 9/6/17
   */
 /*
- * File:   hipofile.h
+ * File:   writer.h
  * Author: gavalian
  *
  * Created on April 11, 2017, 2:07 PM
@@ -127,6 +156,8 @@ class writer {
      virtual ~writer(){};
 
      void addEvent(hipo::event &hevent);
+     void addEvent(std::vector<char> &vec, int size = -1);
+     
      void writeRecord(recordbuilder &builder);
      void open(const char *filename);
      void close();

--- a/hipo4/writer.h
+++ b/hipo4/writer.h
@@ -1,32 +1,3 @@
-//******************************************************************************
-//*       ██╗  ██╗██╗██████╗  ██████╗     ██╗  ██╗    ██████╗                  *
-//*       ██║  ██║██║██╔══██╗██╔═══██╗    ██║  ██║   ██╔═████╗                 *
-//*       ███████║██║██████╔╝██║   ██║    ███████║   ██║██╔██║                 *
-//*       ██╔══██║██║██╔═══╝ ██║   ██║    ╚════██║   ████╔╝██║                 *
-//*       ██║  ██║██║██║     ╚██████╔╝         ██║██╗╚██████╔╝                 *
-//*       ╚═╝  ╚═╝╚═╝╚═╝      ╚═════╝          ╚═╝╚═╝ ╚═════╝                  *
-//************************ Jefferson National Lab (2017) ***********************
-/*
- *   Copyright (c) 2017.  Jefferson Lab (JLab). All rights reserved. Permission
- *   to use, copy, modify, and distribute  this software and its documentation
- *   for educational, research, and not-for-profit purposes, without fee and
- *   without a signed licensing agreement.
- *
- *   IN NO EVENT SHALL JLAB BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL
- *   INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING
- *   OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF JLAB HAS
- *   BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *   JLAB SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- *   PURPOSE. THE HIPO DATA FORMAT SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
- *   ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". JLAB HAS NO OBLIGATION TO
- *   PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
- *
- *   This software was developed under the United States Government license.
- *   For more information contact author at gavalian@jlab.org
- *   Department of Experimental Nuclear Physics, Jefferson Lab.
- */
 /*
  *This sowftware was developed at Jefferson National Laboratory.
  */
@@ -88,7 +59,7 @@
   * @since 6.0 9/6/17
   */
 /*
- * File:   writer.h
+ * File:   hipofile.h
  * Author: gavalian
  *
  * Created on April 11, 2017, 2:07 PM
@@ -156,14 +127,15 @@ class writer {
      virtual ~writer(){};
 
      void addEvent(hipo::event &hevent);
-     void addEvent(std::vector<char> &vec, int size = -1);
-     
      void writeRecord(recordbuilder &builder);
      void open(const char *filename);
      void close();
      void showSummary();
      void addDictionary(hipo::dictionary &dict);
      hipo::dictionary &getDictionary(){ return writerDictionary;}
+     void setUserIntegerOne(long userIntOne);
+     void setUserIntegerTwo(long userIntTwo);
+     void flush();
 };
 
 };


### PR DESCRIPTION
The clas12writer can now write special (tag 1) banks. It will do so by default but the option is given to users. It will write special banks with a tag 1. Users can also set their own tags, but this requires writing to the file each time the tag is changed. Some changes were made to hipo4/writer and hipo4/recordbuilder (see below).

The second commit made sure to have as few changes with hipo4 as possible. These changes are:
recordbuilder: Added setter functions for user integers one and two and function declarations to the header file. Changed "build" function to write the correct user words instead of always 0. 
writer: Added setter functions for the user words one and two. Added "flush" function to write the record that is kept in the record builder's buffer. This was necessary to make sure that a given user word is written with the correct set of events.

Some benchmarks:
For 5038542 tag 0 events and 3064011 tag 1 events:
Reading and writing tag 0 and tag 1 takes 145s (66s CPU time), the output file is 7.5GB.
Reading and writing only tag 0 events took 140s (59s CPU time), the output file is 7.3GB.
Only reading tag 0 events took 107s (30s CPU time).