### PR TITLE
Rcdb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,32 @@ add_definitions(-D__LZ4__)
 #after Lz4 change include to include
 set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+#include rcdb c++ header library
+IF (DEFINED ENV{RCDB_HOME})
+  include_directories($ENV{RCDB_HOME}/cpp/include)
+ENDIF (DEFINED ENV{RCDB_HOME})
+
+#find path to mysql include directory
+FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
+  /usr/local/include/mysql
+  /usr/include/mysql
+  )
+
+#find path to mysql library
+SET(MYSQL_NAMES mysqlclient mysqlclient_r)
+FIND_LIBRARY(MYSQL_LIBRARY
+  NAMES ${MYSQL_NAMES}
+  PATHS /usr/lib /usr/local/lib /usr/lib64 /usr/local/lib64
+  PATH_SUFFIXES mysql
+  )
+
+#include mysql library and directory if they were found
+IF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
+  include_directories(${MYSQL_INCLUDE_DIR})
+  link_libraries(${MYSQL_LIBRARY})
+  add_definitions(-DRCDB_MYSQL)
+ENDIF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/hipo4)
 add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/hipo4)
 
@@ -44,4 +70,7 @@ add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/Clas12Banks)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Clas12Root)
 add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/Clas12Root)
+
+
+
 

--- a/Clas12Banks/CMakeLists.txt
+++ b/Clas12Banks/CMakeLists.txt
@@ -1,6 +1,16 @@
-ROOT_GENERATE_DICTIONARY(G__Clas12Banks   helflip.h  helonline.h runconfig.h event.h ftbevent.h particle.h ftbparticle.h mcparticle.h scaler.h vtp.h particle_detector.h scintillator.h tracker.h traj.h forwardtagger.h cherenkov.h calorimeter.h covmatrix.h region_particle.h region_ft.h region_fdet.h region_cdet.h clas12writer.h clas12reader.h  mesonex_trigger.h  scaler_reader.h LINKDEF Clas12LinkDef.h)
+#Only compile rcdb_reader if the path to RCDB library is set in RCDB_HOME.
+IF (DEFINED ENV{RCDB_HOME})
 
-add_library(Clas12Banks SHARED  helflip.cpp helonline.cpp runconfig.cpp event.cpp ftbevent.cpp particle.cpp ftbparticle.cpp mcparticle.cpp scaler.cpp vtp.cpp particle_detector.cpp scintillator.cpp tracker.cpp traj.cpp forwardtagger.cpp cherenkov.cpp calorimeter.cpp covmatrix.cpp region_particle.cpp region_ft.cpp region_fdet.cpp region_cdet.cpp clas12writer.cpp clas12reader.cpp mesonex_trigger.cpp scaler_reader.cpp G__Clas12Banks.cxx)
+   ROOT_GENERATE_DICTIONARY(G__Clas12Banks   helflip.h  helonline.h runconfig.h event.h ftbevent.h particle.h ftbparticle.h mcparticle.h scaler.h vtp.h particle_detector.h scintillator.h tracker.h traj.h forwardtagger.h cherenkov.h calorimeter.h covmatrix.h region_particle.h region_ft.h region_fdet.h region_cdet.h clas12writer.h clas12reader.h rcdb_reader.h mesonex_trigger.h  scaler_reader.h  LINKDEF Clas12LinkDef.h)
+   add_library(Clas12Banks SHARED  helflip.cpp helonline.cpp runconfig.cpp event.cpp ftbevent.cpp particle.cpp ftbparticle.cpp mcparticle.cpp scaler.cpp vtp.cpp particle_detector.cpp scintillator.cpp tracker.cpp traj.cpp forwardtagger.cpp cherenkov.cpp calorimeter.cpp covmatrix.cpp region_particle.cpp region_ft.cpp region_fdet.cpp region_cdet.cpp clas12writer.cpp clas12reader.cpp rcdb_reader.cpp mesonex_trigger.cpp scaler_reader.cpp  G__Clas12Banks.cxx)
+
+ELSE (DEFINED ENV{RCDB_HOME})
+     ROOT_GENERATE_DICTIONARY(G__Clas12Banks   helflip.h  helonline.h runconfig.h event.h ftbevent.h particle.h ftbparticle.h mcparticle.h scaler.h vtp.h particle_detector.h scintillator.h tracker.h traj.h forwardtagger.h cherenkov.h calorimeter.h covmatrix.h region_particle.h region_ft.h region_fdet.h region_cdet.h clas12writer.h clas12reader.h mesonex_trigger.h  scaler_reader.h  LINKDEF Clas12LinkDef.h)
+     add_library(Clas12Banks SHARED  helflip.cpp helonline.cpp runconfig.cpp event.cpp ftbevent.cpp particle.cpp ftbparticle.cpp mcparticle.cpp scaler.cpp vtp.cpp particle_detector.cpp scintillator.cpp tracker.cpp traj.cpp forwardtagger.cpp cherenkov.cpp calorimeter.cpp covmatrix.cpp region_particle.cpp region_ft.cpp region_fdet.cpp region_cdet.cpp clas12writer.cpp clas12reader.cpp mesonex_trigger.cpp scaler_reader.cpp  G__Clas12Banks.cxx)
+
+ENDIF (DEFINED ENV{RCDB_HOME})
+
+
 
 target_link_libraries(Clas12Banks ${ROOT_LIBRARIES} Hipo4)
 

--- a/Clas12Banks/Clas12LinkDef.h
+++ b/Clas12Banks/Clas12LinkDef.h
@@ -30,6 +30,7 @@
 #pragma link C++ class clas12::region_cdet+;
 #pragma link C++ class clas12::clas12writer+;
 #pragma link C++ class clas12::clas12reader+;
+#pragma link C++ class clas12::rcdb_reader+;
 #pragma link C++ class clas12::scaler_reader+;
 #pragma link C++ class clas12::mesonex_trigger+;
 #endif

--- a/Clas12Banks/rcdb_reader.cpp
+++ b/Clas12Banks/rcdb_reader.cpp
@@ -1,0 +1,128 @@
+#include "rcdb_reader.h"
+
+namespace clas12 {
+
+  /* Empty constructor needed to link _connection to database.
+   */
+  rcdb_reader::rcdb_reader(){}
+
+  /* Function to return a bool type value, given the value's name and a run
+   * number.
+   * Will return false if the condition doesn't exist for this run, or the run
+   * number isn't recorded.
+   * If the value is not of type bool the program will stop.
+   */
+  bool rcdb_reader::getBoolValue(int runNb, std::string value){
+    auto cnd = _connection->GetCondition(runNb, value);
+    bool val = false;
+    if(!cnd){
+      cout<<"The condition "<<value<<" does not exist for run "<<runNb<<"."<<endl;
+    }
+    else{
+      try{
+	val = cnd->ToBool();
+      }
+      catch(int e)
+	{
+	  cout<<"The value for this condition is not a bool."<<std::endl;
+	}
+    }
+    return val;
+  }
+
+  /* Function to return an integer type value, given the value's name and a run
+   * number.
+   * Will return -1 if the condition doesn't exist for this run, or the run
+   * number isn't recorded.
+   * If the value is not of type integer the program will stop.
+   */
+  int rcdb_reader::getIntValue(int runNb, std::string value){
+    auto cnd = _connection->GetCondition(runNb, value);
+    int val = -1;
+    if(!cnd){
+      cout<<"The condition "<<value<<" does not exist for run "<<runNb<<"."<<endl;
+    }
+    else{
+      try{
+	val = cnd->ToInt();
+      }
+      catch(int e)
+	{
+	  cout<<"The value for this condition is not an int."<<endl;
+	}
+    }
+    return val;
+  }
+
+  /* Function to return a double type value, given the value's name and a run
+   * number.
+   * Will return -1 if the condition doesn't exist for this run, or the run
+   * number isn't recorded.
+   * If the value is not of type double the program will stop.
+   */
+  double rcdb_reader::getDoubleValue(int runNb, std::string value){
+    auto cnd = _connection->GetCondition(runNb, value);
+    double val = -1;
+    if(!cnd){
+      cout<<"The condition "<<value<<" does not exist for run "<<runNb<<"."<<endl;
+    }
+    else{
+      try{
+	val = cnd->ToDouble();
+      }
+      catch(int e)
+	{
+	  cout<<"The value for this condition is not a double."<<endl;
+	}
+    }
+    return val;
+  }
+
+  /* Function to return a string type value, given the value's name and a run
+   * number.
+   * Will return Error if the condition doesn't exist for this run, or the run
+   * number isn't recorded.
+   * If the value is not of type string the program will stop.
+   */
+  std::string rcdb_reader::getStringValue(int runNb, std::string value){
+    auto cnd = _connection->GetCondition(runNb, value);
+    std::string val = "Error";
+    if(!cnd){
+      cout<<"The condition "<<value<<" does not exist for run "<<runNb<<"."<<endl;
+    }
+    else{
+      try{
+	val = cnd->ToString();
+      }
+      catch(int e)
+	{
+	  cout<<"The value for this condition is not a double."<<endl;
+	}
+    }
+    return val;
+  }
+  
+  /* Function to return a time_point type value, given the value's name and a 
+   * run number.
+   * Will return the current time if the condition doesn't exist for this run,
+   * or if the run number isn't recorded.
+   * If the value is not of type time_point the program will stop.
+   */
+  std::chrono::time_point<std::chrono::system_clock> rcdb_reader::getTimeValue(int runNb, std::string value){
+    auto cnd = _connection->GetCondition(runNb, value);
+    std::chrono::time_point<std::chrono::system_clock> val = std::chrono::system_clock::now();
+    if(!cnd){
+      cout<<"The condition "<<value<<" does not exist for run "<<runNb<<"."<<endl;
+    }
+    else{
+      try{
+	val = cnd->ToTime();
+      }
+      catch(int e)
+	{
+	  cout<<"The value for this condition is not a double."<<endl;
+	}
+    }
+    return val;
+    }
+}

--- a/Clas12Banks/rcdb_reader.h
+++ b/Clas12Banks/rcdb_reader.h
@@ -1,0 +1,40 @@
+/*
+ * File:   rcdb_reader.h
+ * Author: rtyson
+ */
+
+#ifndef RCDB_READER_H
+#define RCDB_READER_H
+
+#include "RCDB/Connection.h" 
+#include <iostream>
+
+#include <chrono>
+#include <string>
+
+namespace clas12 {
+  using std::cout;
+  using std::endl;
+
+  class rcdb_reader {
+
+  public:
+
+    rcdb_reader();
+    virtual ~rcdb_reader()=default;
+
+    bool getBoolValue(int runNb, std::string value);
+    int getIntValue(int runNb, std::string value);
+    double getDoubleValue(int runNb, std::string value);
+    std::string getStringValue(int runNb, std::string value);
+    std::chrono::time_point<std::chrono::system_clock> getTimeValue(int runNb, std::string value);
+
+  private:
+
+    rcdb::Connection *_connection = new rcdb::Connection("mysql://rcdb@clasdb.jlab.org/rcdb", true);    
+
+  };
+
+}
+
+#endif /* RCDB_READER_H */

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The Clas12Banks implementation can be used independent of ROOT, although current
 
 For actual Clas12Banks definitions see [HIPO4 DSTs](https://clasweb.jlab.org/wiki/index.php/CLAS12_DSTs)
 
-An interface to the c++ [Run Conditions DataBase](https://github.com/JeffersonLab/rcdb/wiki/Cpp) requires downloading the relevant code from https://github.com/JeffersonLab/rcdb . This is optional and depends on the existence of an environment variable containing the path to the RCDB code.
+An interface to the c++ [Run Conditions DataBase](https://github.com/JeffersonLab/rcdb/wiki/Cpp) requires downloading the relevant code from https://github.com/JeffersonLab/rcdb . This is optional and depends on the existence of an environment variable containing the path to the RCDB code. The interface also requires having MySQL installed.
 
 ## Also see c++ function for accessing banks "Cheat sheet" AccesssingBankDataInCpp.txt in the top level directory.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The Clas12Banks implementation can be used independent of ROOT, although current
 
 For actual Clas12Banks definitions see [HIPO4 DSTs](https://clasweb.jlab.org/wiki/index.php/CLAS12_DSTs)
 
+An interface to the c++ [Run Conditions DataBase](https://github.com/JeffersonLab/rcdb/wiki/Cpp) requires downloading the relevant code from https://github.com/JeffersonLab/rcdb . This is optional and depends on the existence of an environment variable containing the path to the RCDB code.
+
 ## Also see c++ function for accessing banks "Cheat sheet" AccesssingBankDataInCpp.txt in the top level directory.
 
 The Clas12Root package depends on both Hipo and Clas12Banks. This provides ROOT-like analysis tools for operating on clas12 hipo DSTs.
@@ -35,6 +37,10 @@ git clone --recurse-submodules https://github.com/jeffersonlab/clas12root.git
 
 cd clas12root
 
+#To download the RCDB interface 
+
+git clone --recurse-submodules https://github.com/jeffersonlab/rcdb.git
+
 ## To setup Run ROOT
 
 for cshrc
@@ -45,6 +51,10 @@ setenv PATH "$PATH":"$CLAS12ROOT/bin"
 
 setenv HIPO /Where/Is/hipo
 
+#To use the RCDB interface 
+
+setenv RCDB_HOME /Where/Is/rcdb
+
 or for bash
 
 export CLAS12ROOT=$PWD
@@ -52,6 +62,10 @@ export CLAS12ROOT=$PWD
 export PATH="$PATH":"$CLAS12ROOT/bin"
 
 export HIPO=/Where/Is/hipo
+
+#To use the RCDB interface 
+
+export RCDB_HOME /Where/Is/rcdb
 
 ## To install
 
@@ -358,3 +372,11 @@ Start a ROOT note book :
       	root --notebook
 
 Click on the notebook CLAS12Writer3Pi.ipynb and follow the tutorial
+
+## Ex 8 Reading from the Run Conditions DataBase
+
+An interface to the run conditions database is implemented by the class rcdb_reader. It will open a connection to rcdb@clasdb.jlab.org/rcdb and allow you to retrieve condition values for a given run. This class interfaces to the Run Conditions DataBase c++ code, more information on it can be found at https://github.com/JeffersonLab/rcdb/wiki/Cpp and the database itself can be viewed at https://clasweb.jlab.org/rcdb/. An example on how to use the rcdb_reader interface can be found in RunRoot/Ex8_RcdbReader.C
+
+To try the example
+
+       clas12root RunRoot/Ex8_RcdbReader.C+

--- a/RunRoot/Ex8_RcdbReader.C
+++ b/RunRoot/Ex8_RcdbReader.C
@@ -1,0 +1,37 @@
+#include <cstdlib>
+#include <iostream>
+#include "rcdb_reader.h"
+#include <string>
+#include <chrono>
+#include <ctime>
+
+using namespace clas12;
+using namespace std;
+
+void Ex8_RcdbReader(){
+
+  /* Creates the interface to RCDB header library.
+   * Immediately opens a connection to rcdb@clasdb.jlab.org/rcdb.
+   */
+  rcdb_reader rcdb;
+
+  /* Examples of how to access different conditions for run 12277.
+   * If the wrong type is asked for a given condition the code will 
+   * stop running.
+   * If the run or condition doesn't exist an error message is given 
+   * and a wrong value is returned.
+   * The database and conditions can be viewed at 
+   * https://clasweb.jlab.org/rcdb/ .
+   */
+  int val = rcdb.getIntValue(12277, "event_count");
+  double val2 = rcdb.getDoubleValue(12277, "beam_energy");
+  double val3 = rcdb.getDoubleValue(12277, "beam_current");
+  std::string val4 = rcdb.getStringValue(12277, "target");
+  bool val5 = rcdb.getBoolValue(12277, "is_valid_run_end");
+
+  cout<<"Event count: "<<val<<" Beam energy: "<<val2<<endl;
+  cout<<"Beam current: "<<val3<<" Target: "<<val4<<endl;
+  cout<<"Run is valid: "<<val5<<endl;
+
+
+}


### PR DESCRIPTION
This introduces the rcdb_reader class which is an interface to the RCDB c++ code from https://github.com/JeffersonLab/rcdb . More instruction on how to run the code is found here https://github.com/JeffersonLab/rcdb/wiki/Cpp.

The rcdb_reader will open a connection to rcdb@clasdb.jlab.org/rcdb and allow for the values of conditions to be returned for a given run. It uses several functions of format getTYPEValue(runNb, condition), where type is one of bool, int, double, string, time_point. If the condition or the run don't exist then the functions will print an error message and return a wrong value. It's left to the user to notice the error message and that the value is wrong. If the TYPE is wrong for the condition an error is thrown by the RCDB c++ code which will stop the program.

An example of the rcdb_reader is given in RunRoot/Ex8_RcdbReader.C, and the database can be viewed at https://clasweb.jlab.org/rcdb/.
Note: The only conditions that use a time_point are run_start_time and run_end_time. Currently they seem to return the UNIX start time (ie January 1st 1970), which happens if a time_point isn't initialised. This is true for the rcdb_reader but also by just using the RCDB code.  You can try this in the simple example in rcdb/cpp/examples/simple.cpp with:
    auto cnd2 = connection.GetCondition(run, "run_start_time");
    chrono::time_point<chrono::system_clock> val6 = cnd2->ToTime();
    time_t ttp = chrono::system_clock::to_time_t(val6);
    cout<<"start time: "<<ctime(&ttp)<<endl;
I'm sure the conversion from time_point to time_t works, you can try it by replacing cnd2->ToTime(); with chrono::system_clock::now();.
This probably means there's a bug either in the rcdb code or the actual database (although the start times look right). In any case, although I've given the option to ask for a time_point I haven't included it in the example.

The CMake code will first check if the environment variable RCDB_HOME is set. If it isn't the case we assume that the user doesn't want to use the rcdb_reader and the rcdb_reader class won't be compiled, and the RCDB library won't be included. This means that users can update their version of clas12root without having to download the RCDB library. The CMake code will then check that MySQL is installed on the user's system, find the path to the relevant include and libraries and add them. If the user doesn't have MySQL this won't stop clas12root from compiling.

I've also update the readme to provide instruction on how to get the RCDB library and compile clas12root correctly.