### PR TITLE
Rcdb restricting queries

### DIFF
--- a/Clas12Banks/clas12reader.cpp
+++ b/Clas12Banks/clas12reader.cpp
@@ -99,6 +99,9 @@ namespace clas12 {
     _conditionNames.push_back("beam_energy");
     _conditionValues.push_back(rcdb.getDoubleValue(runNo, "beam_current"));
     _conditionNames.push_back("beam_current");
+
+    //Close connection to database.
+    rcdb.Close();
     
   }
 

--- a/Clas12Banks/clas12reader.cpp
+++ b/Clas12Banks/clas12reader.cpp
@@ -76,6 +76,41 @@ namespace clas12 {
     
     makeListBanks();
     
+    #ifdef RCDB_MYSQL
+    queryRcdb();
+    #endif
+    
+  }
+
+  ///////////////////////////////////////////////////////////////////////
+  ///Function to query RCDB and record most relevant run conditions.
+  ///This is only called once to avoid overloading the database.
+  void clas12reader::queryRcdb(){
+    next();//need to read first event
+    auto runNo=runconfig()->getRun(); //get run number for this file
+    getReader().gotoRecord(0); //reset back to start
+    rcdb_reader rcdb; //initialise rcdb_reader
+
+    //Incomplete list of run conditions.
+    //If you add to this list please add values and names in the same order.
+    _conditionValues.push_back(rcdb.getDoubleValue(runNo, "event_count"));
+    _conditionNames.push_back("event_count");
+    _conditionValues.push_back(rcdb.getDoubleValue(runNo, "beam_energy"));
+    _conditionNames.push_back("beam_energy");
+    _conditionValues.push_back(rcdb.getDoubleValue(runNo, "beam_current"));
+    _conditionNames.push_back("beam_current");
+    
+  }
+
+  /////////////////////////////////////////////////////////////////////////
+  ///Function to return a condition value for a given condition name.
+  double clas12reader::getRunCondition(std::string condition){
+    for (int i=0; i<_conditionNames.size();i++){
+      if(_conditionNames[i] == condition){
+	return _conditionValues[i];
+      }
+    }
+    return 0;
   }
   
   ///////////////////////////////////////////////////////

--- a/Clas12Banks/clas12reader.h
+++ b/Clas12Banks/clas12reader.h
@@ -45,6 +45,9 @@
 #include <string>
 #include <iostream>
 
+#ifdef RCDB_MYSQL
+   #include "rcdb_reader.h"
+#endif
 
 namespace clas12 {
   using std::cout;
@@ -170,6 +173,9 @@ namespace clas12 {
 	hipoRead();
       _event.getStructure(*bank);
     }
+
+    //rcdb
+    double getRunCondition(std::string condition);
     
     protected:
 
@@ -177,6 +183,11 @@ namespace clas12 {
     
     
     private:
+
+    //rcdb
+    void queryRcdb();
+    std::vector<double> _conditionValues;
+    std::vector<std::string> _conditionNames;
 
     void hipoRead(){
       _reader.read(_event);

--- a/Clas12Banks/rcdb_reader.h
+++ b/Clas12Banks/rcdb_reader.h
@@ -28,6 +28,7 @@ namespace clas12 {
     double getDoubleValue(int runNb, std::string value);
     std::string getStringValue(int runNb, std::string value);
     std::chrono::time_point<std::chrono::system_clock> getTimeValue(int runNb, std::string value);
+    void Close(){_connection->Close();};
 
   private:
 

--- a/RunRoot/Ex8b_RcdbReader.C
+++ b/RunRoot/Ex8b_RcdbReader.C
@@ -1,6 +1,5 @@
 #include <cstdlib>
 #include <iostream>
-#include "rcdb_reader.h"
 #include "clas12reader.h"
 #include <string>
 #include <chrono>
@@ -11,35 +10,16 @@ using namespace std;
 
 void Ex8b_RcdbReader(){
 
-
-  clas12reader c12("/a/hipo/file.hipo",{0});//needs tag-0 event
-  c12.next();//need to read first event
-  auto runNo=c12.runconfig()->getRun(); //get run number for this file
-  c12.getReader().gotoRecord(0); //reset back to start
+  /* The clas12reader opens a connection to the RCDB when it initialises.
+   * This connection is then closed but some run conditions are stored.
+   * This is done to avoid overloading the database.
+   */
+  clas12reader c12("/a/hipo/file.hipo");
   
-  /* Creates the interface to RCDB header library.
-   * Immediately opens a connection to rcdb@clasdb.jlab.org/rcdb.
-   */
-  rcdb_reader rcdb;
-
-  /* Examples of how to access different conditions for runNo.
-   * If the wrong type is asked for a given condition the code will 
-   * stop running.
-   * If the run or condition doesn't exist an error message is given 
-   * and a wrong value is returned.
-   * The database and conditions can be viewed at 
-   * https://clasweb.jlab.org/rcdb/ .
-   */
-  int val = rcdb.getIntValue(runNo, "event_count");
-  double val2 = rcdb.getDoubleValue(runNo, "beam_energy");
-  double val3 = rcdb.getDoubleValue(runNo, "beam_current");
-  std::string val4 = rcdb.getStringValue(runNo, "target");
-  bool val5 = rcdb.getBoolValue(runNo, "is_valid_run_end");
-
-  cout<<"Run number : "<<runNo<<endl;
-  cout<<"Event count: "<<val<<" Beam energy: "<<val2<<endl;
-  cout<<"Beam current: "<<val3<<" Target: "<<val4<<endl;
-  cout<<"Run is valid: "<<val5<<endl;
+  //The following run conditions can be returned directly by c12
+  cout<<"Event count: "<<c12.getRunCondition("event_count")<<endl;
+  cout<<"Beam energy: "<<c12.getRunCondition("beam_energy")<<endl;
+  cout<<"Beam current: "<<c12.getRunCondition("beam_current")<<endl;
 
 
 }


### PR DESCRIPTION
A connection to the RCDB is now opened by the clas12reader when it initializes. The c12reader then saves the value of run conditions and closes the connection. The run condition values can be accessed at any point.

NB:
c12reader will only open a connection to the RCDB if RCDB_MYSQL is defined. This is done by CMake if MySql is installed.
Only 3 conditions (event count, beam current, beam energy) are stored by c12reader for the moment. If there's demand for more this is easy to add to the code.
There's nothing to restrict users from accessing the database using the rcdb_reader class.