### PR TITLE
Clasqa db access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ IF (DEFINED ENV{CLASQADB_HOME})
 
   include_directories($ENV{CLASQADB_HOME}/srcC/rapidjson/include)
   include_directories($ENV{CLASQADB_HOME}/srcC/include)
+  #clasqaDB header contains function definitions which are not inlined
+  #including this header causes multiple definitions of these functions
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}  -Wl,--allow-multiple-definition")
 
 ENDIF (DEFINED ENV{CLASQADB_HOME})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ IF (DEFINED ENV{CLASQADB_HOME})
   #clasqaDB header contains function definitions which are not inlined
   #including this header causes multiple definitions of these functions
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}  -Wl,--allow-multiple-definition")
-
+  add_definitions(-DCLAS_QADB)
 ENDIF (DEFINED ENV{CLASQADB_HOME})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/hipo4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,13 @@ add_definitions(-D__LZ4__)
 #after Lz4 change include to include
 set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+#include clasqaDB c++ library and rapidjson library
+IF (DEFINED ENV{CLASQADB_HOME})
 
+  include_directories($ENV{CLASQADB_HOME}/srcC/rapidjson/include)
+  include_directories($ENV{CLASQADB_HOME}/srcC/include)
+
+ENDIF (DEFINED ENV{CLASQADB_HOME})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/hipo4)
 add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/hipo4)
@@ -46,7 +52,5 @@ add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/Clas12Banks)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Clas12Root)
 add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/Clas12Root)
-
-
 
 

--- a/Clas12Banks/CMakeLists.txt
+++ b/Clas12Banks/CMakeLists.txt
@@ -27,14 +27,15 @@ ENDIF (DEFINED ENV{RCDB_HOME})
 #Only compile rcdb_reader if the path to RCDB library is set in RCDB_HOME.
 IF (DEFINED ENV{RCDB_HOME})
 
-   ROOT_GENERATE_DICTIONARY(G__Clas12Banks   helflip.h  helonline.h runconfig.h event.h ftbevent.h particle.h ftbparticle.h mcparticle.h scaler.h vtp.h particle_detector.h scintillator.h tracker.h traj.h forwardtagger.h cherenkov.h calorimeter.h covmatrix.h region_particle.h region_ft.h region_fdet.h region_cdet.h region_band.h clas12writer.h clas12reader.h rcdb_reader.h mesonex_trigger.h  scaler_reader.h  LINKDEF Clas12LinkDef.h)
-   add_library(Clas12Banks SHARED  helflip.cpp helonline.cpp runconfig.cpp event.cpp ftbevent.cpp particle.cpp ftbparticle.cpp mcparticle.cpp scaler.cpp vtp.cpp particle_detector.cpp scintillator.cpp tracker.cpp traj.cpp forwardtagger.cpp cherenkov.cpp calorimeter.cpp covmatrix.cpp region_particle.cpp region_ft.cpp region_fdet.cpp region_cdet.cpp region_band.cpp clas12writer.cpp clas12reader.cpp rcdb_reader.cpp mesonex_trigger.cpp scaler_reader.cpp  G__Clas12Banks.cxx)
+   ROOT_GENERATE_DICTIONARY(G__Clas12Banks   helflip.h  helonline.h runconfig.h event.h ftbevent.h particle.h ftbparticle.h mcparticle.h scaler.h vtp.h particle_detector.h scintillator.h tracker.h traj.h forwardtagger.h cherenkov.h calorimeter.h covmatrix.h region_particle.h region_ft.h region_fdet.h region_cdet.h region_band.h clas12writer.h clas12reader.h rcdb_reader.h mesonex_trigger.h  scaler_reader.h jsonFileMerger.h qadb_reader.h LINKDEF Clas12LinkDef.h)
+   add_library(Clas12Banks SHARED  helflip.cpp helonline.cpp runconfig.cpp event.cpp ftbevent.cpp particle.cpp ftbparticle.cpp mcparticle.cpp scaler.cpp vtp.cpp particle_detector.cpp scintillator.cpp tracker.cpp traj.cpp forwardtagger.cpp cherenkov.cpp calorimeter.cpp covmatrix.cpp region_particle.cpp region_ft.cpp region_fdet.cpp region_cdet.cpp region_band.cpp clas12writer.cpp clas12reader.cpp rcdb_reader.cpp mesonex_trigger.cpp scaler_reader.cpp jsonFileMerger.cpp qadb_reader.cpp G__Clas12Banks.cxx)
 
 ELSE (DEFINED ENV{RCDB_HOME})
-     ROOT_GENERATE_DICTIONARY(G__Clas12Banks   helflip.h  helonline.h runconfig.h event.h ftbevent.h particle.h ftbparticle.h mcparticle.h scaler.h vtp.h particle_detector.h scintillator.h tracker.h traj.h forwardtagger.h cherenkov.h calorimeter.h covmatrix.h region_particle.h region_ft.h region_fdet.h region_cdet.h region_band.h clas12writer.h clas12reader.h mesonex_trigger.h  scaler_reader.h  LINKDEF Clas12LinkDef.h)
-     add_library(Clas12Banks SHARED  helflip.cpp helonline.cpp runconfig.cpp event.cpp ftbevent.cpp particle.cpp ftbparticle.cpp mcparticle.cpp scaler.cpp vtp.cpp particle_detector.cpp scintillator.cpp tracker.cpp traj.cpp forwardtagger.cpp cherenkov.cpp calorimeter.cpp covmatrix.cpp region_particle.cpp region_ft.cpp region_fdet.cpp region_cdet.cpp region_band.cpp clas12writer.cpp clas12reader.cpp mesonex_trigger.cpp scaler_reader.cpp  G__Clas12Banks.cxx)
+     ROOT_GENERATE_DICTIONARY(G__Clas12Banks   helflip.h  helonline.h runconfig.h event.h ftbevent.h particle.h ftbparticle.h mcparticle.h scaler.h vtp.h particle_detector.h scintillator.h tracker.h traj.h forwardtagger.h cherenkov.h calorimeter.h covmatrix.h region_particle.h region_ft.h region_fdet.h region_cdet.h region_band.h clas12writer.h clas12reader.h mesonex_trigger.h  scaler_reader.h jsonFileMerger.h qadb_reader.h LINKDEF Clas12LinkDef.h)
+     add_library(Clas12Banks SHARED  helflip.cpp helonline.cpp runconfig.cpp event.cpp ftbevent.cpp particle.cpp ftbparticle.cpp mcparticle.cpp scaler.cpp vtp.cpp particle_detector.cpp scintillator.cpp tracker.cpp traj.cpp forwardtagger.cpp cherenkov.cpp calorimeter.cpp covmatrix.cpp region_particle.cpp region_ft.cpp region_fdet.cpp region_cdet.cpp region_band.cpp clas12writer.cpp clas12reader.cpp mesonex_trigger.cpp scaler_reader.cpp jsonFileMerger.cpp qadb_reader.cpp G__Clas12Banks.cxx)
 
 ENDIF (DEFINED ENV{RCDB_HOME})
+
 
 
 

--- a/Clas12Banks/CMakeLists.txt
+++ b/Clas12Banks/CMakeLists.txt
@@ -1,6 +1,18 @@
+set(CLASS_LIST_CPP helflip.cpp helonline.cpp runconfig.cpp event.cpp ftbevent.cpp particle.cpp ftbparticle.cpp mcparticle.cpp scaler.cpp vtp.cpp particle_detector.cpp scintillator.cpp tracker.cpp traj.cpp forwardtagger.cpp cherenkov.cpp calorimeter.cpp covmatrix.cpp region_particle.cpp region_ft.cpp region_fdet.cpp region_cdet.cpp region_band.cpp clas12writer.cpp clas12reader.cpp mesonex_trigger.cpp scaler_reader.cpp)
+
+set(CLASS_LIST_H helflip.h  helonline.h runconfig.h event.h ftbevent.h particle.h ftbparticle.h mcparticle.h scaler.h vtp.h particle_detector.h scintillator.h tracker.h traj.h forwardtagger.h cherenkov.h calorimeter.h covmatrix.h region_particle.h region_ft.h region_fdet.h region_cdet.h region_band.h clas12writer.h clas12reader.h mesonex_trigger.h  scaler_reader.h)
+
+IF (DEFINED ENV{CLASQADB_HOME})
+  set(CLASS_LIST_CPP ${CLASS_LIST_CPP} jsonFileMerger.cpp qadb_reader.cpp)
+  set(CLASS_LIST_H ${CLASS_LIST_H} jsonFileMerger.h qadb_reader.h)
+ENDIF (DEFINED ENV{CLASQADB_HOME})
+
 #include rcdb c++ header library
 IF (DEFINED ENV{RCDB_HOME})
   include_directories($ENV{RCDB_HOME}/cpp/include)
+  set(CLASS_LIST_CPP ${CLASS_LIST_CPP} rcdb_reader.cpp)
+  set(CLASS_LIST_H ${CLASS_LIST_H} rcdb_reader.h)
+
   #find path to mysql include directory
   FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
     /usr/local/include/mysql
@@ -24,23 +36,10 @@ IF (DEFINED ENV{RCDB_HOME})
 
 ENDIF (DEFINED ENV{RCDB_HOME})
 
-#Only compile rcdb_reader if the path to RCDB library is set in RCDB_HOME.
-IF (DEFINED ENV{RCDB_HOME})
-
-   ROOT_GENERATE_DICTIONARY(G__Clas12Banks   helflip.h  helonline.h runconfig.h event.h ftbevent.h particle.h ftbparticle.h mcparticle.h scaler.h vtp.h particle_detector.h scintillator.h tracker.h traj.h forwardtagger.h cherenkov.h calorimeter.h covmatrix.h region_particle.h region_ft.h region_fdet.h region_cdet.h region_band.h clas12writer.h clas12reader.h rcdb_reader.h mesonex_trigger.h  scaler_reader.h jsonFileMerger.h qadb_reader.h LINKDEF Clas12LinkDef.h)
-   add_library(Clas12Banks SHARED  helflip.cpp helonline.cpp runconfig.cpp event.cpp ftbevent.cpp particle.cpp ftbparticle.cpp mcparticle.cpp scaler.cpp vtp.cpp particle_detector.cpp scintillator.cpp tracker.cpp traj.cpp forwardtagger.cpp cherenkov.cpp calorimeter.cpp covmatrix.cpp region_particle.cpp region_ft.cpp region_fdet.cpp region_cdet.cpp region_band.cpp clas12writer.cpp clas12reader.cpp rcdb_reader.cpp mesonex_trigger.cpp scaler_reader.cpp jsonFileMerger.cpp qadb_reader.cpp G__Clas12Banks.cxx)
-
-ELSE (DEFINED ENV{RCDB_HOME})
-     ROOT_GENERATE_DICTIONARY(G__Clas12Banks   helflip.h  helonline.h runconfig.h event.h ftbevent.h particle.h ftbparticle.h mcparticle.h scaler.h vtp.h particle_detector.h scintillator.h tracker.h traj.h forwardtagger.h cherenkov.h calorimeter.h covmatrix.h region_particle.h region_ft.h region_fdet.h region_cdet.h region_band.h clas12writer.h clas12reader.h mesonex_trigger.h  scaler_reader.h jsonFileMerger.h qadb_reader.h LINKDEF Clas12LinkDef.h)
-     add_library(Clas12Banks SHARED  helflip.cpp helonline.cpp runconfig.cpp event.cpp ftbevent.cpp particle.cpp ftbparticle.cpp mcparticle.cpp scaler.cpp vtp.cpp particle_detector.cpp scintillator.cpp tracker.cpp traj.cpp forwardtagger.cpp cherenkov.cpp calorimeter.cpp covmatrix.cpp region_particle.cpp region_ft.cpp region_fdet.cpp region_cdet.cpp region_band.cpp clas12writer.cpp clas12reader.cpp mesonex_trigger.cpp scaler_reader.cpp jsonFileMerger.cpp qadb_reader.cpp G__Clas12Banks.cxx)
-
-ENDIF (DEFINED ENV{RCDB_HOME})
-
-
-
+ROOT_GENERATE_DICTIONARY(G__Clas12Banks ${CLASS_LIST_H} LINKDEF Clas12LinkDef.h)
+add_library(Clas12Banks SHARED ${CLASS_LIST_CPP} G__Clas12Banks.cxx)
 
 target_link_libraries(Clas12Banks ${ROOT_LIBRARIES} Hipo4)
-
 
 install(TARGETS Clas12Banks
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/Clas12Banks/Clas12LinkDef.h
+++ b/Clas12Banks/Clas12LinkDef.h
@@ -33,4 +33,6 @@
 #pragma link C++ class clas12::rcdb_reader+;
 #pragma link C++ class clas12::scaler_reader+;
 #pragma link C++ class clas12::mesonex_trigger+;
+#pragma link C++ class clas12::jsonFileMerger+;
+#pragma link C++ class clas12::qadb_reader+;
 #endif

--- a/Clas12Banks/clas12reader.cpp
+++ b/Clas12Banks/clas12reader.cpp
@@ -40,8 +40,9 @@ namespace clas12 {
     _useFTBased=other._useFTBased;
     _nToProcess=other._nToProcess;
 
+#ifdef CLAS_QADB   
     if(other._qa.get()) _qa.reset(other._qa.get());
- 
+ #endif
   }
 
   void clas12reader::initReader(){
@@ -197,14 +198,14 @@ namespace clas12 {
     }
     //Special run banks
     if(_brunconfig.get())_event.getStructure(*_brunconfig.get());
-   
+#ifdef CLAS_QADB   
     //check if event has QA requirements and those were met
     if(_qa.get()){
       if(!_qa->passQAReqs(_brunconfig->getEvent())){
 	return false;
       }
     }
-
+#endif
     //now getthe data for the rest of the banks
     if(_bmcparts.get())_event.getStructure(*_bmcparts.get());
     if(_bcovmat.get())_event.getStructure(*_bcovmat.get());
@@ -420,10 +421,11 @@ namespace clas12 {
 
   //////////////////////////////////////////////////////////////
   ///Returns qadb_reader once declared
+#ifdef CLAS_QADB
   qadb_reader * clas12reader::getQAReader(){
     return _qa.get();
   }
-
+#endif
   /////////////////////////////////////////////////////////
   ///make a list of banks
   void clas12reader::makeListBanks(){

--- a/Clas12Banks/clas12reader.cpp
+++ b/Clas12Banks/clas12reader.cpp
@@ -39,8 +39,11 @@ namespace clas12 {
     _zeroOfRestPid=other._zeroOfRestPid;
     _useFTBased=other._useFTBased;
     _nToProcess=other._nToProcess;
+
+    if(other._qa.get()) _qa.reset(other._qa.get());
  
   }
+
   void clas12reader::initReader(){
     _reader.open(_filename.data()); //keep a pointer to the reader
 

--- a/Clas12Banks/clas12reader.cpp
+++ b/Clas12Banks/clas12reader.cpp
@@ -401,15 +401,25 @@ namespace clas12 {
 			    {return dr->par()->getCharge()==ch;});
   }
 
+  ////////////////////////////////////////////////////////////////
+  ///Enable QA skimming.
+  void clas12reader::applyQA(std::string jsonFilePath){
+      _applyQA=true;
+#ifdef CLAS_QADB
+      _qa = new qadb_reader(jsonFilePath);
+#endif
+    };
+
+
   ///////////////////////////////////////////////////////
   ///Checks if an event passes all the QA requirements
   bool clas12reader::passQAReqs(){
+#ifdef CLAS_QADB
     //_runNo may already have been found
     if(_runNo==0){
       _runNo=readQuickRunConfig(_filename);
     }
     int evNo = _brunconfig->getEvent();
-
     //First event always has index 0 which doesn't exist in qaDB
     if(evNo!=0){
       //isOkForAsymmetry already queries _QA, want to avoid doing it twice
@@ -439,6 +449,7 @@ namespace clas12 {
 	return false;
       }
     }
+#endif
     //Event passes all requirements
     return true;
   }

--- a/Clas12Banks/clas12reader.h
+++ b/Clas12Banks/clas12reader.h
@@ -196,8 +196,9 @@ namespace clas12 {
 
     //clasqaDB   
     void applyQA(std::string jsonFilePath);
+#ifdef CLAS_QADB
     qadb_reader * getQAReader();
-    
+#endif    
     protected:
 
     void initReader();

--- a/Clas12Banks/clas12reader.h
+++ b/Clas12Banks/clas12reader.h
@@ -196,8 +196,7 @@ namespace clas12 {
 
     //clasqaDB   
     void applyQA(std::string jsonFilePath);
-    void addQARequirement(std::string req){_reqsQA.push_back(req);};
-    void requireOkForAsymmetry(bool ok){_reqOKAsymmetry=ok;};
+    qadb_reader * getQAReader();
     
     protected:
 
@@ -279,15 +278,9 @@ namespace clas12 {
 
        //rcdb
     int _runNo{0};
-
-    //clasqaDB
     
-    bool _applyQA{false};
-    std::vector<std::string> _reqsQA;
-    bool _reqOKAsymmetry{false};
-    bool passQAReqs();
 #ifdef CLAS_QADB
-    qadb_reader * _qa;
+    std::unique_ptr<qadb_reader> _qa={nullptr};
 #endif
     
     ///////////////////////////////RCDB

--- a/Clas12Banks/clas12reader.h
+++ b/Clas12Banks/clas12reader.h
@@ -195,8 +195,8 @@ namespace clas12 {
 
     //clasqaDB
     void applyQA(std::string jsonFilePath){
-      _jsonFilePath=jsonFilePath;
       _applyQA=true;
+      _qa = new qadb_reader(jsonFilePath);
     };
     void addQARequirement(std::string req){_reqsQA.push_back(req);};
     void requireOkForAsymmetry(bool ok){_reqOKAsymmetry=ok;};
@@ -284,10 +284,10 @@ namespace clas12 {
 
     //clasqaDB
     bool _applyQA{false};
-    std::string _jsonFilePath;
     vector<std::string> _reqsQA;
     bool _reqOKAsymmetry{false};
     bool passQAReqs();
+    qadb_reader * _qa;
     
     ///////////////////////////////RCDB
    private:

--- a/Clas12Banks/clas12reader.h
+++ b/Clas12Banks/clas12reader.h
@@ -39,9 +39,6 @@
 #include "region_band.h"
 #include "scaler_reader.h"
 #include "rcdb_vals.h"
-
-#include "qadb_reader.h"
-
 #include "dictionary.h"
 
 #include <algorithm>
@@ -51,6 +48,10 @@
 
 #ifdef RCDB_MYSQL
    #include "rcdb_reader.h"
+#endif
+
+#ifdef CLAS_QADB
+   #include "qadb_reader.h"
 #endif
 
 namespace clas12 {
@@ -193,11 +194,8 @@ namespace clas12 {
 
     void setEntries(long n){_nToProcess = n;}
 
-    //clasqaDB
-    void applyQA(std::string jsonFilePath){
-      _applyQA=true;
-      _qa = new qadb_reader(jsonFilePath);
-    };
+    //clasqaDB   
+    void applyQA(std::string jsonFilePath);
     void addQARequirement(std::string req){_reqsQA.push_back(req);};
     void requireOkForAsymmetry(bool ok){_reqOKAsymmetry=ok;};
     
@@ -283,11 +281,14 @@ namespace clas12 {
     int _runNo{0};
 
     //clasqaDB
+    
     bool _applyQA{false};
-    vector<std::string> _reqsQA;
+    std::vector<std::string> _reqsQA;
     bool _reqOKAsymmetry{false};
     bool passQAReqs();
+#ifdef CLAS_QADB
     qadb_reader * _qa;
+#endif
     
     ///////////////////////////////RCDB
    private:

--- a/Clas12Banks/clas12reader.h
+++ b/Clas12Banks/clas12reader.h
@@ -40,6 +40,8 @@
 #include "scaler_reader.h"
 #include "rcdb_vals.h"
 
+#include "qadb_reader.h"
+
 #include "dictionary.h"
 
 #include <algorithm>
@@ -190,6 +192,14 @@ namespace clas12 {
     void queryRcdb();
 
     void setEntries(long n){_nToProcess = n;}
+
+    //clasqaDB
+    void applyQA(std::string jsonFilePath){
+      _jsonFilePath=jsonFilePath;
+      _applyQA=true;
+    };
+    void addQARequirement(std::string req){_reqsQA.push_back(req);};
+    void requireOkForAsymmetry(bool ok){_reqOKAsymmetry=ok;};
     
     protected:
 
@@ -271,6 +281,13 @@ namespace clas12 {
 
        //rcdb
     int _runNo{0};
+
+    //clasqaDB
+    bool _applyQA{false};
+    std::string _jsonFilePath;
+    vector<std::string> _reqsQA;
+    bool _reqOKAsymmetry{false};
+    bool passQAReqs();
     
     ///////////////////////////////RCDB
    private:

--- a/Clas12Banks/jsonFileMerger.cpp
+++ b/Clas12Banks/jsonFileMerger.cpp
@@ -1,0 +1,70 @@
+#include "jsonFileMerger.h"
+
+namespace clas12 {
+
+  /*
+   * Function to merge all files that have been passed to the merger.
+   */
+  void jsonFileMerger::mergeAllFiles(){
+    if(_files.size()<2){
+      cout<<"Please provide at least two files"<<endl;
+      return;
+    }
+    Document jsonDOMAll;  
+    //Buffer needed to keep documents in memory.
+    Document jsonDOMBuff[_files.size()];
+    for(int i=0; i<_files.size();i++){
+      char readBuffer[65536];
+      FILE * jsonFile = fopen(_files[i].c_str(),"r");
+      FileReadStream * jsonStream = new FileReadStream(jsonFile,readBuffer,sizeof(readBuffer));
+      jsonDOMBuff[i].ParseStream(*jsonStream);
+      if(i==0){
+	jsonDOMAll.CopyFrom(jsonDOMBuff[i],jsonDOMAll.GetAllocator());
+	
+      } else{
+	mergeJsonFiles(jsonDOMAll,jsonDOMBuff[i],jsonDOMAll.GetAllocator());
+      }
+      fclose(jsonFile);
+    }
+    writeJsonFile(jsonDOMAll);
+  }
+
+  /*
+   * Function to merge two json files.
+   * Target contains information from a file to append to source.
+   */
+  void jsonFileMerger::mergeJsonFiles(Value& target, Value& source, Value::AllocatorType& allocator) {
+    assert(target.IsObject());
+    assert(source.IsObject());
+    for (Value::MemberIterator itr = source.MemberBegin(); itr != source.MemberEnd(); ++itr){
+      target.AddMember(itr->name, itr->value, allocator);
+    }
+  }
+
+  /*
+   * Function to write jsonDOM to a file.
+   */
+  void jsonFileMerger::writeJsonFile(Document &jsonDOM){
+    FILE* fp = fopen(_outFilePath.c_str(), "wb"); 
+ 
+    char writeBuffer[65536];
+    FileWriteStream os(fp, writeBuffer, sizeof(writeBuffer));
+ 
+    Writer<FileWriteStream> writer(os);
+    jsonDOM.Accept(writer);
+ 
+    fclose(fp);
+  }
+
+  /*
+   * Function to print out jsonDOM, mostly used for debugging.
+   */
+  void jsonFileMerger::print(Document &jsonDOM){        
+    StringBuffer sb;
+    PrettyWriter<StringBuffer> writer(sb);
+    jsonDOM.Accept(writer);
+    auto str = sb.GetString();
+    printf("%s\n", str);
+  }
+
+}

--- a/Clas12Banks/jsonFileMerger.h
+++ b/Clas12Banks/jsonFileMerger.h
@@ -1,0 +1,38 @@
+#ifndef JSONFILEMERGER_H
+#define JSONFILEMERGER_H
+
+#include "rapidjson/document.h"
+#include "rapidjson/filereadstream.h"
+#include "rapidjson/filewritestream.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/prettywriter.h"
+
+#include <string>
+#include <iostream>
+#include <vector>
+
+namespace clas12 {
+  using std::string;
+  using std::cout;
+  using std::endl;
+  using namespace rapidjson;
+  
+  class jsonFileMerger{
+
+  public:
+    jsonFileMerger()=default;
+    jsonFileMerger(std::string outFilePath){_outFilePath=outFilePath;};
+    virtual ~jsonFileMerger()=default;
+
+    void addFile(string file){_files.push_back(file);}
+    void mergeAllFiles();
+
+  private: 
+    string _outFilePath;
+    std::vector<string> _files;
+    void mergeJsonFiles(Value& target, Value& source, Value::AllocatorType& allocator);   
+    void writeJsonFile(Document &jsonDOM);
+    void print(Document &jsonDOM);
+  };
+}
+#endif /* JSONFILEMERGER_H */

--- a/Clas12Banks/qadb_reader.cpp
+++ b/Clas12Banks/qadb_reader.cpp
@@ -1,0 +1,7 @@
+#include "qadb_reader.h"
+
+namespace clas12 {
+
+  qadb_reader::qadb_reader(string jsonFilePath):_qa{jsonFilePath.c_str()}{};
+
+}

--- a/Clas12Banks/qadb_reader.cpp
+++ b/Clas12Banks/qadb_reader.cpp
@@ -2,6 +2,43 @@
 
 namespace clas12 {
 
-  qadb_reader::qadb_reader(string jsonFilePath):_qa{jsonFilePath.c_str()}{};
+  qadb_reader::qadb_reader(string jsonFilePath, int runNo):_qa{jsonFilePath.c_str()}{_runNo=runNo;};
+
+    ///////////////////////////////////////////////////////
+  ///Checks if an event passes all the QA requirements
+  bool qadb_reader::passQAReqs(int evNo){
+    //First event always has index 0 which doesn't exist in qaDB
+    if(evNo!=0){
+      //isOkForAsymmetry already queries _QA, want to avoid doing it twice
+      bool passAsymReq=true;
+      bool queried=false;
+      if(_reqOKAsymmetry){
+	passAsymReq = isOkForAsymmetry(_runNo,evNo);
+	queried=true;
+      } else {
+	queried = query(_runNo,evNo);
+      }
+    
+      //An event may be ok for asymmetry but have other defects
+      if(passAsymReq && queried){
+	//If an event is Golden it won't have other defects
+	if(_reqGolden){
+	  return isGolden();
+	} else {
+	  //loop over all requirements asked by user
+	  for(string req: _reqsQA){
+	    if (hasDefect(req.c_str())){
+	      return false;
+	    }
+	  }
+	}
+      } else {
+	return false;
+      }
+    }
+    //Event passes all requirements
+    return true;
+  }
+
 
 }

--- a/Clas12Banks/qadb_reader.h
+++ b/Clas12Banks/qadb_reader.h
@@ -1,0 +1,38 @@
+#ifndef QADB_READER_H
+#define QADB_READER_H
+
+#include "QADB.h"
+#include <iostream>
+#include <string>
+
+namespace clas12 {
+  using std::string;
+  
+  class qadb_reader {
+
+  public:
+
+    qadb_reader(string jsonFilePath);
+    virtual ~qadb_reader()=default;  
+
+    bool query(int runNb, int evNb){return _qa.Query(runNb,evNb);};
+    int getFileNb(){return _qa.GetFilenum();};
+    bool isGolden(){return _qa.Golden();};
+    int getMinEventNb(){return _qa.GetEvnumMin();};
+    int getMaxEventNb(){return _qa.GetEvnumMax();};
+    int getDefect(){return _qa.GetDefect();};
+    int getDefectForSector(int sector){return _qa.GetDefectForSector(sector);};
+    bool hasDefect(const char * defectName, int sector){return _qa.HasDefect(defectName,sector);};
+    bool hasDefect(const char * defectName){return _qa.HasDefect(defectName);};
+    string getComment(){return _qa.GetComment();};
+
+    bool isOkForAsymmetry(int runNb, int evNb){return _qa.OkForAsymmetry(runNb,evNb);};
+
+  private: 
+
+    QADB _qa;   
+    
+  };
+
+}
+#endif /* QADB_READER_H */

--- a/Clas12Banks/qadb_reader.h
+++ b/Clas12Banks/qadb_reader.h
@@ -4,6 +4,7 @@
 #include "QADB.h"
 #include <iostream>
 #include <string>
+#include <vector>
 
 namespace clas12 {
   using std::string;
@@ -12,7 +13,7 @@ namespace clas12 {
 
   public:
 
-    qadb_reader(string jsonFilePath);
+    qadb_reader(string jsonFilePath, int runNo);
     virtual ~qadb_reader()=default;  
 
     bool query(int runNb, int evNb){return _qa.Query(runNb,evNb);};
@@ -28,9 +29,18 @@ namespace clas12 {
 
     bool isOkForAsymmetry(int runNb, int evNb){return _qa.OkForAsymmetry(runNb,evNb);};
 
+    void addQARequirement(string req){_reqsQA.push_back(req);};
+    void requireOkForAsymmetry(bool ok){_reqOKAsymmetry=ok;};
+    void requireGolden(bool ok){_reqGolden=ok;};
+    bool passQAReqs(int evNo);
+
   private: 
 
-    QADB _qa;   
+    QADB _qa;  
+    std::vector<string> _reqsQA;
+    bool _reqOKAsymmetry{false};
+    bool _reqGolden{false};
+    int _runNo{0};
     
   };
 

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ In the case where many files are to be analysed use of HipoChain is recommended 
 See also Ex1_CLAS12ReaderChain.C for the relevent lines.
 
 ## Ex 9 Skimming Based on Data Quality Assurance
-clas12root can use the Quality Assurance database .json files found at https://github.com/c-dilks/clasqaDB/tree/master to reject events that have been identified as failing to meet certain requirements. This can implemented in an analysis using the clas12reader using the functions
+clas12root can use the Quality Assurance database .json files found at https://github.com/c-dilks/clasqaDB/tree/master to reject events that have been identified as failing to meet certain requirements. This can implemented in an analysis using the clas12reader with the functions
 
       c12.applyQA("/absolute/path/to/qaDB.json");
       c12.requireOkForAsymmetry(true);
@@ -468,4 +468,11 @@ where applyQA takes as argument a .json file containing the QA database, require
     LowLiveTime: live time < 0.9
     Misc: miscellaneous defect
 
-Example usage is found in RunRoot/Ex9_QualityAssurance.C. More information on the Quality Assurance process is found in the RGA analysis note.
+The QA database is contained in several .json files that can be found on the clasqaDB github [repository](https://github.com/c-dilks/clasqaDB/tree/master). These can merged within clas12root using the jsonFileMerger class with the functions:
+
+    jsonFileMerger merger("/absolute/path/for/output.json");
+    merger.addFile("/absolute/path/for/input1.json");
+    merger.addFile("/absolute/path/for/input2.json");
+    merger.mergeAllFiles();
+
+Example usage can be found at RunRoot/Ex9_QualityAssurance.C. More information on the Quality Assurance process can be found in the RGA analysis note.

--- a/README.md
+++ b/README.md
@@ -457,12 +457,12 @@ See also Ex1_CLAS12ReaderChain.C for the relevent lines.
 clas12root can use the Quality Assurance database .json files found at https://github.com/c-dilks/clasqaDB/tree/master to reject events that have been identified as failing to meet certain requirements. This is implemented in an analysis using the clas12reader with the functions
 
       c12.applyQA("/absolute/path/to/qaDB.json");
-      c12.requireOkForAsymmetry(true);
-      c12.addQARequirement("MarginalOutlier");	
+      c12.getQAReader()->requireOkForAsymmetry(true);
+      c12.getQAReader()->requireGolden(true);
+      c12.getQAReader()->addQARequirement("MarginalOutlier");	
 
-where applyQA takes as argument a .json file containing the QA database, requireOkForAsymmetry(true) requires only events that were identified as suitable for asymmetry calculations, and addQARequirement("Requirement") allows to reject events that fail to meet the specified requirement. These can be:
+where applyQA takes as argument a .json file containing the QA database. requireOkForAsymmetry(true) requires only events that were identified as suitable for asymmetry calculations, and requireGolden(true) requires only events without any defects. addQARequirement("Requirement") allows to reject events that fail to meet the specified requirement. These can be:
 
-    Golden: if no defect bits are assigned in any sector
     TotalOutlier: outlier N/F, but not terminal, marginal, or sector loss
     TerminalOutlier: outlier N/F of first or last file of run
     MarginalOutlier: marginal outlier N/F, within one stddev of cut line

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ The Clas12Root package depends on both Hipo and Clas12Banks. This provides ROOT-
 ```bash
 git clone --recurse-submodules https://github.com/jeffersonlab/clas12root.git
 cd clas12root
-#To download the RCDB interface 
+#To download the RCDB repository
 git clone --recurse-submodules https://github.com/jeffersonlab/rcdb.git
+#To download the clasqaDB repository 
+git clone --recurse-submodules https://github.com/c-dilks/clasqaDB.git
 ```
 
 ## To setup Run ROOT
@@ -452,7 +454,7 @@ In the case where many files are to be analysed use of HipoChain is recommended 
 See also Ex1_CLAS12ReaderChain.C for the relevent lines.
 
 ## Ex 9 Skimming Based on Data Quality Assurance
-clas12root can use the Quality Assurance database .json files found at https://github.com/c-dilks/clasqaDB/tree/master to reject events that have been identified as failing to meet certain requirements. This can implemented in an analysis using the clas12reader with the functions
+clas12root can use the Quality Assurance database .json files found at https://github.com/c-dilks/clasqaDB/tree/master to reject events that have been identified as failing to meet certain requirements. This is implemented in an analysis using the clas12reader with the functions
 
       c12.applyQA("/absolute/path/to/qaDB.json");
       c12.requireOkForAsymmetry(true);
@@ -468,7 +470,7 @@ where applyQA takes as argument a .json file containing the QA database, require
     LowLiveTime: live time < 0.9
     Misc: miscellaneous defect
 
-The QA database is contained in several .json files that can be found on the clasqaDB github [repository](https://github.com/c-dilks/clasqaDB/tree/master). These can merged within clas12root using the jsonFileMerger class with the functions:
+The QA database is contained in several .json files that can be found on the clasqaDB github [repository](https://github.com/c-dilks/clasqaDB/tree/master). These can be merged within clas12root using the jsonFileMerger class with the functions:
 
     jsonFileMerger merger("/absolute/path/for/output.json");
     merger.addFile("/absolute/path/for/input1.json");

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ For actual Clas12Banks definitions see [HIPO4 DSTs](https://clasweb.jlab.org/wik
 
 An interface to the c++ [Run Conditions DataBase](https://github.com/JeffersonLab/rcdb/wiki/Cpp) requires downloading the relevant code from https://github.com/JeffersonLab/rcdb . This is optional and depends on the existence of an environment variable containing the path to the RCDB code. The interface also requires having MySQL installed.
 
+clas12root provides an interface to the clasqaDB c++ code to allow skimming of events based on the Data Quality Assurance. This is optional and depends on the existence of an environment variable containing the path to the clasqaDB code, which must be downloaded from https://github.com/c-dilks/clasqaDB/tree/master.
+
 ## Also see c++ function for accessing banks "Cheat sheet" AccesssingBankDataInCpp.txt in the top level directory.
 
 The Clas12Root package depends on both Hipo and Clas12Banks. This provides ROOT-like analysis tools for operating on clas12 hipo DSTs.
@@ -48,6 +50,8 @@ setenv PATH "$PATH":"$CLAS12ROOT/bin"
 setenv HIPO /Where/Is/hipo
 #To use the RCDB interface 
 setenv RCDB_HOME /Where/Is/rcdb
+#To use clasqaDB interface
+setenv CLASQADB_HOME /Where/Is/clasqaDB
 ```
 
 or for bash
@@ -57,6 +61,8 @@ export PATH="$PATH":"$CLAS12ROOT/bin"
 export HIPO=/Where/Is/hipo
 #To use the RCDB interface 
 export RCDB_HOME /Where/Is/rcdb
+#To use clasqaDB interface
+export CLASQADB_HOME /Where/Is/clasqaDB
 ```
 
 ## To install
@@ -444,3 +450,22 @@ In the case where many files are to be analysed use of HipoChain is recommended 
 
 
 See also Ex1_CLAS12ReaderChain.C for the relevent lines.
+
+## Ex 9 Skimming Based on Data Quality Assurance
+clas12root can use the Quality Assurance database .json files found at https://github.com/c-dilks/clasqaDB/tree/master to reject events that have been identified as failing to meet certain requirements. This can implemented in an analysis using the clas12reader using the functions
+
+      c12.applyQA("/absolute/path/to/qaDB.json");
+      c12.requireOkForAsymmetry(true);
+      c12.addQARequirement("MarginalOutlier");	
+
+where applyQA takes as argument a .json file containing the QA database, requireOkForAsymmetry(true) requires only events that were identified as suitable for asymmetry calculations, and addQARequirement("Requirement") allows to reject events that fail to meet the specified requirement. These can be:
+
+    Golden: if no defect bits are assigned in any sector
+    TotalOutlier: outlier N/F, but not terminal, marginal, or sector loss
+    TerminalOutlier: outlier N/F of first or last file of run
+    MarginalOutlier: marginal outlier N/F, within one stddev of cut line
+    SectorLoss: N/F diminished within a sector for several consecutive files
+    LowLiveTime: live time < 0.9
+    Misc: miscellaneous defect
+
+Example usage is found in RunRoot/Ex9_QualityAssurance.C. More information on the Quality Assurance process is found in the RGA analysis note.

--- a/RunRoot/Ex9_QualityAssurance.C
+++ b/RunRoot/Ex9_QualityAssurance.C
@@ -49,10 +49,10 @@ void Ex9_QualityAssurance(){
    * See RGA analysis note and clasqaDB github repository for
    * additional information.
    */
-  c12.requireOkForAsymmetry(true);
-  c12.addQARequirement("MarginalOutlier");
-  c12.addQARequirement("TotalOutlier");
-  c12.addQARequirement("Golden");
+  c12.getQAReader()->requireOkForAsymmetry(true);
+  c12.getQAReader()->requireGolden(true);
+  c12.getQAReader()->addQARequirement("MarginalOutlier");
+  c12.getQAReader()->addQARequirement("TotalOutlier");
 
   //The analysis can then proceed as usual.
   while(c12.next()) {

--- a/RunRoot/Ex9_QualityAssurance.C
+++ b/RunRoot/Ex9_QualityAssurance.C
@@ -1,0 +1,62 @@
+#include <cstdlib>
+#include <iostream>
+#include "clas12reader.h"
+#include "jsonFileMerger.h"
+
+
+using namespace clas12;
+using namespace std;
+
+void Ex9_QualityAssurance(){
+
+
+  /*
+   * The jsonFileMerger class included in clas12root allows to
+   * quickly merge several jason files. It takes as an
+   * argument the absolute path for the merged output.
+   *
+   * addFile takes as argument the absolute path for an input 
+   * .json file to be merged.
+   *
+   * mergeAllFiles merges all the added files and saves the output
+   * to the specified location
+   */
+  jsonFileMerger merger("/absolute/path/for/output.json");
+  merger.addFile("/absolute/path/for/input1.json");
+  merger.addFile("/absolute/path/for/input2.json");
+  merger.mergeAllFiles();
+  
+  //clas12reader declared as usual.
+  clas12reader c12("/path/to/data.hipo");
+
+  /*
+   * applyQA specifies to the clas12reader that quality assurance
+   * cuts will be applied, based on the .json file given as an 
+   * argument. This file should contain the Clas12 Quality Assurance
+   * database.
+   */
+  c12.applyQA("/absolute/path/to/qaDB.json");
+
+  /*
+   * Several quality assurance requirements can be specified.
+   * requireOkForAsymmetry requires that an event was deemed
+   * suitable for asymmetry measurements.
+   *
+   * addRequirement requires that the event was not identified
+   * as, for example, a marginal outlier. Several requirements
+   * can be assigned at the same time.
+   * 
+   * See RGA analysis note and clasqaDB github repository for
+   * additional information.
+   */
+  c12.requireOkForAsymmetry(true);
+  c12.addQARequirement("MarginalOutlier");
+  c12.addQARequirement("TotalOutlier");
+  c12.addQARequirement("Golden");
+
+  //The analysis can then proceed as usual.
+  while(c12.next()) {
+    //Do rest of analysis...
+  }
+
+}


### PR DESCRIPTION
This introduces two new classes to access the Quality Assurance database from json files by interfacing to the clasqaDB c++ code. The first class allows to quickly merge json files, and the second provides the interface to clasqaDB. This second class is then used in clas12reader to allow skimming of events based on QA requirements. This works by first calling c12.applyQA with the absolute path to a json file containing the QA database. Requirements can then be added with addRequirement("Requirement"), or isOkForAsymmetry(true) which only allows events that have been identified as suitable for asymmetry measurements.

An example is provided in RunRoot/Ex9_QualityAssurance.C and instructions have been added to the README.

Some things to note:
- To make these optional, compiling the two new classes and adding to the clas12reader are dependent on an environment variable being set to the home directory of clasqaDB. Clas12Banks/CMakeLists was modified to simplify the logic behind compiling certain classes or not based on environment variables being set.
- The clasqaDB is a header library with definitions of the functions in the header file. This causes a multiple definition error when including the library in a project as these functions are not inlined (see https://stackoverflow.com/questions/51602927/why-linker-error-multiple-definitions-with-only-one-library-using-cmake-3-4 for more details). The "-Wl,--allow-multiple-definition" linker options were added to the project (if the QADB_HOME environment variable is set) to avoid this issue.