### PR TITLE
Clasqa db v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,15 +37,15 @@ add_definitions(-D__LZ4__)
 set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 #include clasqaDB c++ library and rapidjson library
-IF (DEFINED ENV{CLASQADB_HOME})
+IF (DEFINED ENV{QADB})
 
-  include_directories($ENV{CLASQADB_HOME}/srcC/rapidjson/include)
-  include_directories($ENV{CLASQADB_HOME}/srcC/include)
+  include_directories($ENV{QADB}/srcC/rapidjson/include)
+  include_directories($ENV{QADB}/srcC/include)
   #clasqaDB header contains function definitions which are not inlined
   #including this header causes multiple definitions of these functions
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}  -Wl,--allow-multiple-definition")
   add_definitions(-DCLAS_QADB)
-ENDIF (DEFINED ENV{CLASQADB_HOME})
+ENDIF (DEFINED ENV{QADB})
 
 
 

--- a/Clas12Banks/CMakeLists.txt
+++ b/Clas12Banks/CMakeLists.txt
@@ -5,11 +5,11 @@ set(CLASS_LIST_CPP helflip.cpp helonline.cpp runconfig.cpp event.cpp ftbevent.cp
 
 set(CLASS_LIST_H helflip.h  helonline.h runconfig.h event.h ftbevent.h particle.h ftbparticle.h mcparticle.h scaler.h vtp.h particle_detector.h scintillator.h tracker.h traj.h forwardtagger.h cherenkov.h calorimeter.h covmatrix.h region_particle.h region_ft.h region_fdet.h region_cdet.h region_band.h clas12writer.h clas12reader.h mesonex_trigger.h  scaler_reader.h clas12databases.h  qadb_reader.h ccdb_reader.h rcdb_reader.h)
 
-IF (DEFINED ENV{CLASQADB_HOME})
+IF (DEFINED ENV{QADB})
   set(CLASS_LIST_CPP ${CLASS_LIST_CPP} jsonFileMerger.cpp)
   set(CLASS_LIST_H ${CLASS_LIST_H} jsonFileMerger.h)
   add_definitions(-DCLAS_QADB)
-ENDIF (DEFINED ENV{CLASQADB_HOME})
+ENDIF (DEFINED ENV{QADB})
 
 #include rcdb c++ header library
 IF (DEFINED ENV{CCDB_HOME})

--- a/Clas12Banks/clas12databases.cpp
+++ b/Clas12Banks/clas12databases.cpp
@@ -7,9 +7,9 @@ namespace clas12 {
   
   string clas12databases::_RcdbPath="";
   string clas12databases::_CcdbPath="";
-  string clas12databases::_QadbPath="";
+  //string clas12databases::_QadbPath="";
   
-  void clas12databases::SetQADBConnection(const string& name){_QadbPath=FullPath(name);}
+  //void clas12databases::SetQADBConnection(const string& name){_QadbPath=FullPath(name);}
   void clas12databases::SetCCDBLocalConnection(const string& name){_CcdbPath="sqlite://"+FullPath(name);}
   void clas12databases::SetCCDBRemoteConnection(){_CcdbPath="mysql://clas12reader@clasdb.jlab.org/clas12";}
   void clas12databases::SetRCDBLocalConnection(const string& name){_RcdbPath="sqlite://"+FullPath(name);}
@@ -26,11 +26,11 @@ namespace clas12 {
   {
     std::cout<<"clas12databases() rcdb path "<<_RcdbPath<<" "<<_myRcdbPath<<std::endl;
     std::cout<<"clas12databases() ccdb path "<<_CcdbPath<<std::endl;
-    std::cout<<"clas12databases() qadb path "<<_QadbPath<<std::endl;
+    //std::cout<<"clas12databases() qadb path "<<_QadbPath<<std::endl;
 
     _myRcdbPath=_RcdbPath;
     _myCcdbPath=_CcdbPath;
-    _myQadbPath=_QadbPath;
+    //_myQadbPath=_QadbPath;
 
     initDBs();
    }
@@ -39,7 +39,7 @@ namespace clas12 {
     
     _myRcdbPath=other._myRcdbPath;
     _myCcdbPath=other._myCcdbPath;
-    _myQadbPath=other._myQadbPath;
+    //_myQadbPath=other._myQadbPath;
     
     initDBs();
 
@@ -47,7 +47,6 @@ namespace clas12 {
      qadb_requireOkForAsymmetry(other._qadbReqOKAsymmetry);
      qadb_requireGolden(other._qadbReqGolden);
      qadb_setQARequirements(other._qadbReqsQA);
-     
     }
  
     return *this;
@@ -56,7 +55,7 @@ namespace clas12 {
     
     _myRcdbPath=other._myRcdbPath;
     _myCcdbPath=other._myCcdbPath;
-    _myQadbPath=other._myQadbPath;
+    //_myQadbPath=other._myQadbPath;
     
     
     initDBs();
@@ -72,7 +71,7 @@ namespace clas12 {
   void clas12databases::initDBs(){
     std::cout<<"clas12databases() rcdb path "<<_myRcdbPath<<std::endl;
     std::cout<<"clas12databases() ccdb path "<<_myCcdbPath<<std::endl;
-    std::cout<<"clas12databases() qadb path "<<_myQadbPath<<std::endl;
+    //std::cout<<"clas12databases() qadb path "<<_myQadbPath<<std::endl;
 
      
     if(_myCcdbPath.empty()==false)
@@ -85,12 +84,11 @@ namespace clas12 {
 	_rcdb.reset( new rcdb_reader{_myRcdbPath.data()} );
     }
     
-    if(_myQadbPath.empty()==false){
-      _qadb.reset( new qadb_reader{_myQadbPath.data()} );
-      qadb_requireOkForAsymmetry(_qadbReqOKAsymmetry);
-      qadb_requireGolden(_qadbReqGolden);
-      qadb_setQARequirements(_qadbReqsQA);
-    }
+    
+    _qadb.reset( new qadb_reader{0} );
+    qadb_requireOkForAsymmetry(_qadbReqOKAsymmetry);
+    qadb_requireGolden(_qadbReqGolden);
+    qadb_setQARequirements(_qadbReqsQA);  
 
 }
   //update run number to each database

--- a/Clas12Banks/clas12databases.h
+++ b/Clas12Banks/clas12databases.h
@@ -26,7 +26,7 @@ namespace clas12 {
     //where to make database connections
     static string  _RcdbPath;//!
     static string  _CcdbPath;//!
-    static string  _QadbPath;//!
+    //static string  _QadbPath;//!
 
   public:
     
@@ -40,7 +40,7 @@ namespace clas12 {
     void notifyRun(int runNb);
 
     
-    static void SetQADBConnection(const string& name);
+    //static void SetQADBConnection(const string& name);
     static void SetCCDBLocalConnection(const string& name);
     static void SetCCDBRemoteConnection();
     static void SetRCDBLocalConnection(const string& name);
@@ -57,7 +57,7 @@ namespace clas12 {
  
     const string&  ccdbPath() const {return _myCcdbPath;}
     const string&  rcdbPath() const {return _myRcdbPath;}
-    const string&  qadbPath() const {return _myQadbPath;}
+    //const string&  qadbPath() const {return _myQadbPath;}
 
 
  
@@ -65,7 +65,7 @@ namespace clas12 {
     //I would rather this was not needed here
     //but it is to make sure it gets passed to PROOF
     void qadb_addQARequirement(string req){ _qadb->addQARequirement(req);_qadbReqsQA.push_back(req);};
-    void qadb_setQARequirements( std::vector<string> reqs){_qadb->setQARequirements(reqs); _qadbReqsQA = reqs; };
+    void qadb_setQARequirements( std::vector<string> reqs){_qadb->setQARequirements(reqs); _qadbReqsQA = reqs;};
 
     void qadb_requireOkForAsymmetry(bool ok){_qadb->requireOkForAsymmetry(ok);_qadbReqOKAsymmetry=ok;};
     void qadb_requireGolden(bool ok){_qadb->requireGolden(ok);_qadbReqGolden=ok;};
@@ -76,7 +76,7 @@ namespace clas12 {
    //names for copying to ROOT file for selector
     string _myRcdbPath;
     string  _myCcdbPath;
-    string  _myQadbPath;
+    //string  _myQadbPath;
 
     int _runNb={0};//!
 

--- a/Clas12Banks/qadb_reader.cpp
+++ b/Clas12Banks/qadb_reader.cpp
@@ -4,56 +4,70 @@ namespace clas12 {
 
 #ifdef CLAS_QADB
   
-  qadb_reader::qadb_reader(string jsonFilePath, int runNo):_qa{jsonFilePath.c_str()}{_runNo=runNo;};
+  qadb_reader::qadb_reader(int runNb):_qa{}{_runNb=runNb;};
 
+  ///////////////////////////////////////////////////////
+  /// Add masks for all QA requirements
+  void qadb_reader::addAllMasks(){
+    for(string req:_reqsQA){
+      addMask(req.c_str(),true);
+    }
+    _masksAdded=true;
+  };
 
   ///////////////////////////////////////////////////////
   ///Checks if an event passes all the QA requirements
-
-  bool qadb_reader::passQAReqs(int evNo){
+  bool qadb_reader::passQAReqs(int evNb){
     //First event always has index 0 which doesn't exist in qaDB
-    if(evNo!=0){
+    if(evNb!=0){
       //isOkForAsymmetry already queries _QA, want to avoid doing it twice
       bool passAsymReq=true;
       bool queried=false;
       if(_reqOKAsymmetry){
-	passAsymReq = isOkForAsymmetry(_runNo,evNo);
+	passAsymReq = isOkForAsymmetry(_runNb,evNb);
 	queried=true;
       } else {
-	queried = query(_runNo,evNo);
+	queried = query(_runNb,evNb);
       }
-    
+      if(!_masksAdded){
+	addAllMasks();
+      }
       //An event may be ok for asymmetry but have other defects
       if(passAsymReq && queried){
 	//If an event is Golden it won't have other defects
 	if(_reqGolden){
-	  return isGolden();
-	} else {
-	  //loop over all requirements asked by user
-	  for(string req: _reqsQA){
-	    if (hasDefect(req.c_str())){
-	      return false;
-	    }
+	  //If the event passes the requirements, add charge
+	  if(isGolden(_runNb,evNb)){
+	    _qa.AccumulateCharge();
 	  }
+	  return isGolden(_runNb,evNb);
+	} else {
+	  //If the event passes the requirements, add charge
+	  if(_qa.Pass(_runNb,evNb)){
+	    _qa.AccumulateCharge();
+	  }
+	  return _qa.Pass(_runNb,evNb);
 	}
       } else {
 	return false;
       }
+      //event passes all reqs, just don't want to acc for event 0
+      _qa.AccumulateCharge();
     }
     //Event passes all requirements
     return true;
   }
 
 #else
-  qadb_reader::qadb_reader(string jsonFilePath, int runNo){
-    _runNo=runNo;
+  qadb_reader::qadb_reader(int runNb){
+    _runNb=runNb;
   }
 
 
   ///////////////////////////////////////////////////////
   ///Checks if an event passes all the QA requirements
 
-  bool qadb_reader::passQAReqs(int evNo){
+  bool qadb_reader::passQAReqs(int evNb){
     return true;
   }
   

--- a/Clas12Banks/qadb_reader.h
+++ b/Clas12Banks/qadb_reader.h
@@ -15,7 +15,7 @@ namespace clas12 {
   class qadb_reader {
 
   public:
-    qadb_reader(string jsonFilePath, int runNo=0);
+    qadb_reader(int runNb=0);
     //virtual ~qadb_reader()=default;  
 
 
@@ -23,17 +23,18 @@ namespace clas12 {
   public:
     bool isValid();
     
-    void addQARequirement(string req){_reqsQA.push_back(req);};
-    void setQARequirements( std::vector<string> reqs){_reqsQA=reqs;};
+    void addQARequirement(string req){_reqsQA.push_back(req);_masksAdded=false;};
+    void setQARequirements( std::vector<string> reqs){_reqsQA=reqs;_masksAdded=false;};
     
     void requireOkForAsymmetry(bool ok){_reqOKAsymmetry=ok;};
     void requireGolden(bool ok){_reqGolden=ok;};
-    bool passQAReqs(int evNo);
+    bool passQAReqs(int evNb);
 
-    void setRun(int runNb){_runNo=runNb;}
+    void setRun(int runNb){_runNb=runNb;}
 
     void copySettings(const qadb_reader& other);
-
+    
+    
     
   private:
     
@@ -43,25 +44,35 @@ namespace clas12 {
     std::vector<string> _reqsQA;//!
     bool _reqOKAsymmetry{false};//!
     bool _reqGolden{false};//!
-    int _runNo{0};//!
+    int _runNb{0};//!
+    bool _masksAdded{false};
 
     //ifdefs must go last , or can lead to issues with PROOF
     //i.e. refences are slighty shifted
   
 #ifdef CLAS_QADB
-
+  public:
+    
+    int GetMask(){return _qa.GetMask();};
     bool query(int runNb, int evNb){return _qa.Query(runNb,evNb);};
+    bool querybyFileNb(int runNb, int fileNb){return _qa.QueryByFilenum(runNb,fileNb);};
+    int getMaxFileNb(int runNb){return _qa.GetMaxFilenum(runNb);};
     int getFileNb(){return _qa.GetFilenum();};
-    bool isGolden(){return _qa.Golden();};
+    int getRunNb(){return _qa.GetRunnum();};
+    bool isGolden(int runNb, int evNb){return _qa.Golden(runNb,evNb);};
     int getMinEventNb(){return _qa.GetEvnumMin();};
     int getMaxEventNb(){return _qa.GetEvnumMax();};
-    int getDefect(){return _qa.GetDefect();};
-    int getDefectForSector(int sector){return _qa.GetDefectForSector(sector);};
+    int getDefect(int sector=0){return _qa.GetDefect(sector);};
     bool hasDefect(const char * defectName, int sector){return _qa.HasDefect(defectName,sector);};
     bool hasDefect(const char * defectName){return _qa.HasDefect(defectName);};
     string getComment(){return _qa.GetComment();};
-
     bool isOkForAsymmetry(int runNb, int evNb){return _qa.OkForAsymmetry(runNb,evNb);};
+
+    double getCharge(){return _qa.GetCharge();};
+    void resetAccCharge(){_qa.ResetAccumulatedCharge();};
+    void addMask(const char * defectName, bool maskBit){_qa.SetMaskBit(defectName,maskBit);};
+    void addAllMasks();
+    double getAccCharge(){return _qa.GetAccumulatedCharge();};
 
   private: 
     QADB _qa;//!  

--- a/Clas12Root/HipoChain.h
+++ b/Clas12Root/HipoChain.h
@@ -58,6 +58,7 @@ namespace clas12root {
     
     void AddBeamCharge(Double_t bc){_totBeamCharge+=bc;}
     Double_t TotalBeamCharge() const noexcept{return _totBeamCharge;}
+    void SetTotalBeamCharge(Double_t bc){_totBeamCharge+=bc;}
 
     clas12::clas12databases* db() {return &_db;}
     void ConnectDataBases(){_c12->connectDataBases(&_db);}

--- a/Clas12Root/HipoSelector.cpp
+++ b/Clas12Root/HipoSelector.cpp
@@ -109,6 +109,27 @@ namespace clas12root{
     }
     return kTRUE;
   }
+
+  void HipoSelector::SlaveTerminate()
+  {
+    //Get accumulated charge for each and add to fOutput to concatenate
+    if(qadb()!=nullptr){
+      auto chargeHist=new TH1D("accumulatedCharge","accumulatedCharge",1,0,1);
+      chargeHist->SetBinContent(1,qadb()->getAccCharge());
+      fOutput->Add(chargeHist);
+    }
+
+  }
+
+  void HipoSelector::Terminate()
+  {
+    //Get total charge accumulated charge
+    if(qadb()!=nullptr){
+      auto chargeHist=dynamic_cast<TH1D*>(fOutput->FindObject("accumulatedCharge")); 
+      _chain->SetTotalBeamCharge(chargeHist->GetBinContent(1));
+      std::cout<<"Total accumulated charge: "<<chargeHist->GetBinContent(1)<<std::endl;
+    }
+  }
   
  
 }

--- a/Clas12Root/HipoSelector.h
+++ b/Clas12Root/HipoSelector.h
@@ -37,6 +37,8 @@ namespace clas12root{
       void    SlaveBegin(TTree *tree) override;
       Bool_t  Process(Long64_t entry) override;
       Bool_t  Notify() override;
+      void    SlaveTerminate() override;
+      void    Terminate() override;
       
       virtual Bool_t ProcessEvent() =  0; //loop action to be defined in derived class
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ You may also want to download the latest CCDB sqlite database so you do not need
 ##To download the clasqaDB repository 
 git clone --recurse-submodules https://github.com/c-dilks/clasqaDB.git
 
+cd clasqaDB
+source env.csh
+
 ```
 
 ## To setup Run ROOT
@@ -70,8 +73,8 @@ setenv HIPO /Where/Is/hipo
 setenv RCDB_HOME /Where/Is/rcdb
 #To use the CCDB interface 
 setenv CCDB_HOME /Where/Is/ccdb
-#To use clasqaDB interface
-setenv CLASQADB_HOME /Where/Is/clasqaDB
+#To use clasqaDB interface - already done with source env.csh
+setenv QADB /Where/Is/clasqaDB
 ```
 
 or for bash
@@ -81,8 +84,8 @@ export PATH="$PATH":"$CLAS12ROOT/bin"
 export HIPO=/Where/Is/hipo
 #To use the RCDB interface 
 export RCDB_HOME /Where/Is/rcdb
-#To use clasqaDB interface
-export CLASQADB_HOME /Where/Is/clasqaDB
+#To use clasqaDB interface - already done with source env.csh
+export QADB /Where/Is/clasqaDB
 ```
 
 ## To install
@@ -453,12 +456,11 @@ To use any database you must set the corresponding environment variables
 
 setenv RCDB_HOME /where/is/rcdb
 setenv CCDB_HOME /where/is/ccdb
-setenv CLASQADB_HOME /where/is/clasqaDB
+setenv QADB /where/is/clasqaDB
 
 ands pecify the location of the database before you create your clas12root object
 
         clas12databases::SetCCDBLocalConnection("/where/to/ccdb.sqlite");
-  	clas12databases::SetQADBConnection("/where/to/qaDB.json");
   	clas12databases::SetRCDBRootConnection("/where/to/rcdb.root");
 
 These local files can be created using the $CLAS12ROOT/RunRoot/PrepareDatabases.C macro. You are best copying this locally and editing for any datafiles you want to add to the RCDB file list.
@@ -522,9 +524,7 @@ Or in case you use HipoChain (also for when running PROOF/HipoSelector)
       c12->db().qadb_requireGolden(true);
       c12->db().qadb_addQARequirement("MarginalOutlier");
       c12->db().qadb_addQARequirement("TotalOutlier");
-      c12->applyQA();
-
- 
+      c12->applyQA(); 
     
 where requireOkForAsymmetry(true) requires only events that were identified as suitable for asymmetry calculations, and requireGolden(true) requires only events without any defects. addQARequirement("Requirement") allows to reject events that fail to meet the specified requirement. These can be:
 
@@ -535,16 +535,10 @@ where requireOkForAsymmetry(true) requires only events that were identified as s
     LowLiveTime: live time < 0.9
     Misc: miscellaneous defect
 
-The QA database is contained in several .json files that can be found on the clasqaDB github [repository](https://github.com/c-dilks/clasqaDB/tree/master). These can be merged within clas12root using the jsonFileMerger class with the functions:
+The clasqaDB software also returns the accumulated charge for events that have passed the quality assurance requirements. This is accessed with: 
 
-    jsonFileMerger merger("/absolute/path/for/output.json");
-    merger.addFile("/absolute/path/for/input1.json");
-    merger.addFile("/absolute/path/for/input2.json");
-    merger.mergeAllFiles();
+    c12.db()->qadb()->getAccCharge();
 
-This step can be performed with the RunRoot PrepareDatabases.C script,
-You should copy this locally and edit the HipoChain files if you are using RCDB.
- 
 More information on the Quality Assurance process can be found in the RGA analysis note.
 
 ### Using databases with HipoSelector
@@ -577,7 +571,6 @@ Inside your Selector class for RCDB tables :
 See Ex3b_TestSelector.C and testSelector.C and .h for implementation example. To use the databases you need to comment in the lines
 
     clas12databases::SetCCDBLocalConnection("ccdb.sqlite");
-    clas12databases::SetQADBConnection("qaDB.json");
     clas12databases::SetRCDBRootConnection("rcdb.root");
 
 Having run PrepareDatabases.C with the  HipoChain set for the files you wish to process.

--- a/RunRoot/Ex10_clas12Databases.C
+++ b/RunRoot/Ex10_clas12Databases.C
@@ -18,7 +18,6 @@ void Ex10_clas12Databases(){
   //It is recommended to edit and run the scrpit PrepareDatabases.C
   //for this purpose
   //clas12databases::SetCCDBLocalConnection("ccdb.sqlite");
-  //clas12databases::SetQADBConnection("qaDB.json");
   //clas12databases::SetRCDBRootConnection("rcdb.root");
   
 
@@ -58,6 +57,13 @@ void Ex10_clas12Databases(){
   while(c12.next()) {
    
   }
+
+  /*
+   * The clasqaDB software also provides the accumulated charge for events
+   * that pass the quality assurance requirements.
+   */
+  cout<<"Accumulated charge past QA: "<<c12.db().qadb()->getAccCharge()<<" nC"<<endl;
+
   
   gBenchmark->Stop("db");
   gBenchmark->Print("db");

--- a/RunRoot/Ex10_clas12DatabasesChain.C
+++ b/RunRoot/Ex10_clas12DatabasesChain.C
@@ -18,7 +18,6 @@ void Ex10_clas12DatabasesChain(){
     It is recommended to edit and run the script PrepareDatabases.C
     for this purpose*/
   //clas12databases::SetCCDBLocalConnection("ccdb.sqlite");
-  //clas12databases::SetQADBConnection("qaDB.json");
   //clas12databases::SetRCDBRootConnection("rcdb.root");
   
   clas12root::HipoChain chain;
@@ -90,6 +89,12 @@ void Ex10_clas12DatabasesChain(){
     }
     //break;
   }
+
+   /*
+   * The clasqaDB software also provides the accumulated charge for events
+   * that pass the quality assurance requirements.
+   */
+  cout<<"Accumulated charge past QA: "<<config_c12->db().qadb()->getAccCharge()<<" nC"<<endl;
   
   gBenchmark->Stop("db");
   gBenchmark->Print("db");

--- a/RunRoot/Ex9_QualityAssurance.C
+++ b/RunRoot/Ex9_QualityAssurance.C
@@ -8,23 +8,6 @@ using namespace clas12;
 using namespace std;
 
 void Ex9_QualityAssurance(){
-
-
-  /*
-   * The jsonFileMerger class included in clas12root allows to
-   * quickly merge several jason files. It takes as an
-   * argument the absolute path for the merged output.
-   *
-   * addFile takes as argument the absolute path for an input 
-   * .json file to be merged.
-   *
-   * mergeAllFiles merges all the added files and saves the output
-   * to the specified location
-   */
-  jsonFileMerger merger("/absolute/path/for/output.json");
-  merger.addFile("/absolute/path/for/input1.json");
-  merger.addFile("/absolute/path/for/input2.json");
-  merger.mergeAllFiles();
   
   //clas12reader declared as usual.
   clas12reader c12("/path/to/data.hipo");
@@ -35,7 +18,7 @@ void Ex9_QualityAssurance(){
    * argument. This file should contain the Clas12 Quality Assurance
    * database.
    */
-  c12.applyQA("/absolute/path/to/qaDB.json");
+  c12.applyQA();
 
   /*
    * Several quality assurance requirements can be specified.
@@ -49,14 +32,20 @@ void Ex9_QualityAssurance(){
    * See RGA analysis note and clasqaDB github repository for
    * additional information.
    */
-  c12.getQAReader()->requireOkForAsymmetry(true);
-  c12.getQAReader()->requireGolden(true);
-  c12.getQAReader()->addQARequirement("MarginalOutlier");
-  c12.getQAReader()->addQARequirement("TotalOutlier");
+  c12.qadb()->requireOkForAsymmetry(true);
+  c12.qadb()->requireGolden(true);
+  c12.qadb()->addQARequirement("MarginalOutlier");
+  c12.qadb()->addQARequirement("TotalOutlier");
 
   //The analysis can then proceed as usual.
   while(c12.next()) {
     //Do rest of analysis...
   }
+
+  /*
+   * The clasqaDB software also provides the accumulated charge for events
+   * that pass the quality assurance requirements.
+   */
+  cout<<"Accumulated charge past QA: "<<c12.qadb()->getAccCharge()<<" nC"<<endl;
 
 }

--- a/RunRoot/LoadClas12Root.C
+++ b/RunRoot/LoadClas12Root.C
@@ -19,7 +19,7 @@ void LoadClas12Root(){
  
   gROOT->SetMacroPath(Form("%s:%s/RunRoot/",gROOT->GetMacroPath(),CLAS12ROOT.Data()));
 
-  TString QADB=gSystem->Getenv("CLASQADB_HOME");
+  TString QADB=gSystem->Getenv("QADB");
   if(QADB.Length()!=0){ //For #ifdef CLAS_QADB in header files
     gSystem->AddIncludePath("-DCLAS_QADB");
     gROOT->ProcessLine("#define CLAS_QADB"); //For cling interpreter

--- a/RunRoot/PrepareDatabases.C
+++ b/RunRoot/PrepareDatabases.C
@@ -24,7 +24,7 @@ void PrepareDatabases(){
 
 
   
-#ifdef CLAS_QADB
+  
   
   /*
    * The jsonFileMerger class included in clas12root allows to
@@ -37,9 +37,15 @@ void PrepareDatabases(){
    * mergeAllFiles merges all the added files and saves the output
    * to the specified location
    */
-  
+
+
+/* Deprecated - clasqaDB software now premerges the database files
+and automatically opens these.
+
+
+#ifdef QADB 
   jsonFileMerger merger("qaDB.json");
-  TString QAHOME=gSystem->Getenv("CLASQADB_HOME");
+  TString QAHOME=gSystem->Getenv("QADB");
   std::cout<<"CLASQA adding json file "<<(QAHOME+"/qa.inbending1/qaTree.json").Data()<<std::endl;
   merger.addFile((QAHOME+"/qa.inbending1/qaTree.json").Data());
   std::cout<<"CLASQA adding json file "<<(QAHOME+"/qa.inbending2/qaTree.json").Data()<<std::endl;
@@ -48,7 +54,7 @@ void PrepareDatabases(){
   merger.addFile((QAHOME+"/qa.outbending/qaTree.json").Data());
   merger.mergeAllFiles();
   
-#endif
+#endif*/
 
   
 }


### PR DESCRIPTION
This creates an interface to the updated clasqaDB software. Main changes:

-  The clasqaDB software now uses the environment variable QADB to access the database. We previously used the CLASQADB_HOME environment variable to check the QADB software was installed, this is now changed to QADB.

- The QADB class now doesn't need a path to the database and will load it automatically. The clas12database and qadb_reader classes have been changed accordingly. This also means we don't need the jsonFileMerger class.

- QA Requirements are now added as masks which are checked with the Pass function.

- The qadb_reader class can return the accumulated charge of events that pass QA requirements. 

- Examples and README have been updated.

 